### PR TITLE
docs: add manual install instructions for Claude Code compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,24 @@ A Claude Code [skill](https://docs.anthropic.com/en/docs/claude-code/skills) tha
 
 ## Install
 
+### Using `npx skills` (third-party CLI)
+
 ```bash
 npx skills add tw93/claude-health
+```
+
+> **Note:** `npx skills` installs to `.agents/skills/`, but Claude Code reads skills from `.claude/skills/`. You may need to move the files manually after installation:
+> ```bash
+> mkdir -p .claude/skills && cp -r .agents/skills/health .claude/skills/health
+> ```
+
+### Manual install (recommended)
+
+```bash
+# Clone into the correct Claude Code skills directory
+mkdir -p .claude/skills/health
+curl -fsSL https://raw.githubusercontent.com/tw93/claude-health/main/skills/health/SKILL.md \
+  -o .claude/skills/health/SKILL.md
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- `npx skills add` installs skills to `.agents/skills/`, but Claude Code reads skills from `.claude/skills/`. This causes the `/health` skill to not be recognized after installation.
- Added a **manual install method** (using `curl`) that places `SKILL.md` directly in `.claude/skills/health/`.
- Added a **note** about the path mismatch for `npx skills` users with a workaround (`cp` command).

## Context

After running `npx skills add tw93/claude-health`, the skill files end up in `.agents/skills/health/` instead of `.claude/skills/health/`. Claude Code only scans `.claude/skills/` for skill definitions, so `/health` doesn't appear in the skill list until the files are manually moved.

## Test plan

- [ ] Verify manual install command downloads `SKILL.md` to `.claude/skills/health/`
- [ ] Verify `/health` skill is recognized by Claude Code after manual install
- [ ] Verify the `cp` workaround for `npx skills` users works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)