### PR TITLE
fix: correct owner info in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,8 +3,8 @@
   "name": "claude-health",
   "description": "Configuration health audit skill for Claude Code. Systematically audits CLAUDE.md, rules, skills, hooks, subagents, and verifiers across two parallel agents.",
   "owner": {
-    "name": "tw93",
-    "email": "piao.zhuchao@gmail.com"
+    "name": "Tw93",
+    "email": "hitw93@gmail.com"
   },
   "plugins": [
     {


### PR DESCRIPTION
Sorry about this — I got the owner name and email wrong when I added marketplace.json. Fixed both to match the actual git author info.

- `name`: `tw93` → `Tw93`
- `email`: `piao.zhuchao@gmail.com` → `hitw93@gmail.com`