### PR TITLE
feat: add /health slash command for user invocation

### DIFF
--- a/commands/health.md
+++ b/commands/health.md
@@ -1,0 +1,6 @@
+---
+description: Audit Claude Code configuration health across all layers
+allowed-tools: Bash, Read, Glob, Grep, Agent
+---
+
+Run the health skill to audit this project's Claude Code configuration. Follow all instructions in the health skill's SKILL.md exactly.


### PR DESCRIPTION
## Summary

- The health plugin currently only has a `skills/` directory, so it can only be model-invoked. Adding a `commands/health.md` file enables users to invoke it directly via `/health` in the terminal input.

## Context

Claude Code distinguishes between:
- **Skills** (`skills/*/SKILL.md`): model-invoked based on context
- **Commands** (`commands/*.md`): user-invoked via `/command-name` slash commands

Without a command file, users cannot type `/health` to trigger the audit. This PR adds a thin command wrapper that references the existing SKILL.md logic.

## Test plan

- [ ] Install the plugin and verify `/health` appears in slash command autocomplete
- [ ] Run `/health` and confirm it triggers the full health audit as defined in SKILL.md