### PR TITLE
feat(design): refine design skill

### DIFF
--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -20,8 +20,9 @@ Before writing any code, use AskUserQuestion:
 2. **What is the aesthetic direction?** Name it precisely: dense editorial, raw terminal, ink-on-paper, brutalist grid, warm analog. "Clean and modern" is not a direction.
 3. **What is the one thing this leaves in memory?** A typeface, color system, unexpected motion, asymmetric layout. Pick one and make it obvious.
 4. **What are the hard constraints?** Framework, bundle size, contrast minimums, keyboard accessibility.
+5. **What is the signature micro-interaction?** Scale on press, staggered reveal, or contextual icon animation. Pick one and know exactly how it's implemented.
 
-Do not proceed until all four are answered. State the chosen direction in one sentence, then load `references/design-reference.md` and check the tech stack conflicts table. Name the single CSS strategy before writing the first component.
+Do not proceed until all five are answered. State the chosen direction in one sentence, then load `references/design-reference.md` and check the tech stack conflicts table. Name the single CSS strategy before writing the first component.
 
 Summarize the direction as three lines before writing any code:
 - **Visual thesis**: mood, material, and energy in one sentence (e.g. "warm brutalist editorial with high-contrast ink type and rough paper texture")

--- a/skills/design/references/design-reference.md
+++ b/skills/design/references/design-reference.md
@@ -36,6 +36,8 @@ Final test: if you swapped in completely different content and the layout still 
 
 Check before handoff. These are not aesthetic choices, they are non-negotiable.
 
+> Treat the sections below as craft details, not defaults. Only apply them when they serve the locked visual direction. If removing a detail changes nothing about how the interface feels, leave it out.
+
 ### Accessibility
 - Icon-only buttons need `aria-label`
 - Actions use `<button>`, navigation uses `<a>` (not `<div onClick>`)
@@ -71,8 +73,8 @@ Check before handoff. These are not aesthetic choices, they are non-negotiable.
 - Tabular numbers: use `font-variant-numeric: tabular-nums` for counters, timers, prices, number columns, or any dynamically updating numbers
 
 ### Surfaces
-- Concentric border radius: `outerRadius = innerRadius + padding`; if padding is larger than `24px`, treat layers as separate surfaces and choose each radius independently
-- Optical alignment: buttons with text and icon use slightly less padding on the icon side (e.g., `pl-4 pr-3.5`); play triangles and asymmetric icons shift `1px`–`2px` to the heavier side or fix the SVG directly
-- Shadows over borders: use layered `box-shadow` for depth on cards, buttons, and elevated elements; use actual `border` only for dividers, table cells, and layout separation
-- Image outlines: add a subtle inset outline for consistent depth using `outline: 1px solid rgba(0,0,0,0.1); outline-offset: -1px` (light) or `outline: 1px solid rgba(255,255,255,0.1); outline-offset: -1px` (dark)
-- Minimum hit area: interactive elements need at least 40×40px; extend with a centered pseudo-element when the visible element is smaller; never let hit areas of two interactive elements overlap
+- Concentric border radius: calculate `outerRadius = innerRadius + padding` so nested rounded corners feel intentional, not mechanical; if padding exceeds `24px`, treat layers as separate surfaces and choose each radius independently
+- Optical alignment: nudge icons by eye, not just by math, so buttons feel centered; buttons with text and an icon use slightly less padding on the icon side (e.g., `pl-4 pr-3.5`); play triangles and asymmetric icons should shift `1px`–`2px` toward the heavier side, or fix the SVG directly
+- Shadows over borders: use layered `box-shadow` for depth on cards, buttons, and elevated elements so the surface feels lifted, not fenced in; reserve actual `border` for dividers, table cells, and layout separation
+- Image outlines: add a subtle inset outline so images hold their own depth without altering layout dimensions: `outline: 1px solid rgba(0,0,0,0.1); outline-offset: -1px` (light) or `outline: 1px solid rgba(255,255,255,0.1); outline-offset: -1px` (dark)
+- Minimum hit area: keep every interactive target at least 40×40px so even small controls feel generous and precise; extend with a centered pseudo-element when the visible element is smaller, and never let hit areas of two interactive elements overlap

--- a/skills/design/references/design-reference.md
+++ b/skills/design/references/design-reference.md
@@ -59,5 +59,6 @@ Check before handoff. These are not aesthetic choices, they are non-negotiable.
 - Modals and drawers: `overscroll-behavior: contain`
 
 ### Typography Details
-- `font-variant-numeric: tabular-nums` for number columns or comparisons
-- `text-wrap: balance` or `text-pretty` on headings to prevent awkward line breaks
+- Text wrapping: `text-wrap: balance` on headings and short text blocks (≤6 lines in Chromium, ≤10 in Firefox); `text-wrap: pretty` on body paragraphs and longer text; leave default on code blocks and pre-formatted text
+- Font smoothing: apply `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale` once on the root layout (macOS only)
+- Tabular numbers: use `font-variant-numeric: tabular-nums` for counters, timers, prices, number columns, or any dynamically updating numbers

--- a/skills/design/references/design-reference.md
+++ b/skills/design/references/design-reference.md
@@ -46,7 +46,12 @@ Check before handoff. These are not aesthetic choices, they are non-negotiable.
 - Honor `prefers-reduced-motion`: disable or reduce animations when set
 - Animate `transform`/`opacity` only (compositor-friendly, no layout thrash)
 - Never `transition: all`; list properties explicitly
-- Animations must be interruptible by user input
+- Interruptible animations: prefer CSS transitions for interactive state changes (hover, toggle, open/close) because they retarget mid-animation; reserve keyframe animations for staged sequences that run once (e.g., staggered page enters)
+- Staggered enter: split content into semantic chunks with ~100ms delay; titles into words at ~80ms; typical enter uses `opacity: 0 → 1`, `translateY(12px) → 0`, and `blur(4px) → 0`
+- Subtle exit: use a small fixed `translateY(-12px)` instead of full height; keep duration ~150ms `ease-in`, shorter and softer than enter
+- Contextual icon swaps: animate with `scale: 0.25 → 1`, `opacity: 0 → 1`, and `blur: 4px → 0px`. With Motion: `transition: { type: "spring", duration: 0.3, bounce: 0 }`. Without Motion: keep both icons in DOM (one absolute) and cross-fade with CSS using `cubic-bezier(0.2, 0, 0, 1)`
+- Scale on press: buttons use `scale(0.96)` on active/press via CSS transitions so the press can be interrupted; add a `static` prop to disable when motion would be distracting
+- Page-load guard: use `initial={false}` on `AnimatePresence` for toggles, tabs, and icon swaps to prevent enter animations on first render; do not use it for intentional page-load entrance sequences
 
 ### Performance
 - Transition specificity: never `transition: all`; list exact properties (e.g., `transition-property: scale, opacity`). Tailwind's `transition-transform` covers `transform, translate, scale, rotate`; use `transition-[scale,opacity,filter]` for mixed properties

--- a/skills/design/references/design-reference.md
+++ b/skills/design/references/design-reference.md
@@ -69,3 +69,10 @@ Check before handoff. These are not aesthetic choices, they are non-negotiable.
 - Text wrapping: `text-wrap: balance` on headings and short text blocks (≤6 lines in Chromium, ≤10 in Firefox); `text-wrap: pretty` on body paragraphs and longer text; leave default on code blocks and pre-formatted text
 - Font smoothing: apply `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale` once on the root layout (macOS only)
 - Tabular numbers: use `font-variant-numeric: tabular-nums` for counters, timers, prices, number columns, or any dynamically updating numbers
+
+### Surfaces
+- Concentric border radius: `outerRadius = innerRadius + padding`; if padding is larger than `24px`, treat layers as separate surfaces and choose each radius independently
+- Optical alignment: buttons with text and icon use slightly less padding on the icon side (e.g., `pl-4 pr-3.5`); play triangles and asymmetric icons shift `1px`–`2px` to the heavier side or fix the SVG directly
+- Shadows over borders: use layered `box-shadow` for depth on cards, buttons, and elevated elements; use actual `border` only for dividers, table cells, and layout separation
+- Image outlines: add a subtle inset outline for consistent depth using `outline: 1px solid rgba(0,0,0,0.1); outline-offset: -1px` (light) or `outline: 1px solid rgba(255,255,255,0.1); outline-offset: -1px` (dark)
+- Minimum hit area: interactive elements need at least 40×40px; extend with a centered pseudo-element when the visible element is smaller; never let hit areas of two interactive elements overlap

--- a/skills/design/references/design-reference.md
+++ b/skills/design/references/design-reference.md
@@ -49,6 +49,8 @@ Check before handoff. These are not aesthetic choices, they are non-negotiable.
 - Animations must be interruptible by user input
 
 ### Performance
+- Transition specificity: never `transition: all`; list exact properties (e.g., `transition-property: scale, opacity`). Tailwind's `transition-transform` covers `transform, translate, scale, rotate`; use `transition-[scale,opacity,filter]` for mixed properties
+- GPU compositing: only use `will-change` for `transform`, `opacity`, or `filter`. Never `will-change: all`. Add only when you notice first-frame stutter; do not apply preemptively to every element
 - Images: explicit `width` and `height` (prevents layout shift)
 - Below-fold images: `loading="lazy"`
 - Critical fonts: `font-display: swap`


### PR DESCRIPTION
## Summary
This PR refines the `@skills/design` skill with actionable production-quality guidance and tighter direction-locking constraints. All changes are grounded in the "[make interfaces feel better](https://jakub.kr/writing/details-that-make-interfaces-feel-better)" craft details, reframed to serve the locked visual direction rather than becoming invisible defaults.

### What's changed

**Typography Details**
- Differentiate `text-wrap: balance` (headings/short text) from `pretty` (body paragraphs)
- Add macOS root-level font-smoothing rule
- Expand `tabular-nums` guidance to counters, timers, and dynamic prices

**Performance**
- Ban `transition: all`; use explicit properties and Tailwind bracket syntax
- Add `will-change` guidance: only for `transform`/`opacity`/`filter`, never `all`

**Animation**
- Prefer CSS transitions for interactions (interruptible) and keyframes for one-shot sequences
- Define staggered enter/exit specifics: `~100ms` delay, `translateY(12px/-12px)`, `blur(4px)`, `~150ms ease-in` exit
- Add contextual icon swap animation with exact Motion and CSS-only implementations
- Add scale-on-press (`0.96`) with a `static` prop opt-out
- Add `AnimatePresence initial={false}` guard for default-state elements

**Surfaces**
- Add concentric border radius formula (`outerRadius = innerRadius + padding`)
- Add optical alignment rules for buttons with icons and asymmetric shapes
- Add shadow-as-depth guidance for light and dark modes
- Add subtle image outline pattern
- Enforce minimum `40×40px` hit area with pseudo-element extension

**Direction lock**
- Add fifth `AskUserQuestion`: "What is the signature micro-interaction?"
- Require the chosen interaction to be defined before writing any code

**Craft framing**
- Reframe all baseline checklists as intentional craft details, not defaults
- Rewrite Surfaces rules with intent-first language ("lifted, not fenced in", "generous and precise")
- Add a guardrail: only apply these details when they serve the locked visual direction