### PR TITLE
fix: replace readlink -f with portable fallback for macOS

### DIFF
--- a/scripts/setup-statusline.sh
+++ b/scripts/setup-statusline.sh
@@ -22,7 +22,9 @@ if ! command -v jq &>/dev/null; then
     echo "Installing jq via Homebrew..."
     brew install jq
   else
-    echo "Error: jq is required but not installed. Run: brew install jq" >&2
+    echo "Error: jq is required but not installed." >&2
+    echo "  macOS:  brew install jq" >&2
+    echo "  Linux:  sudo apt-get install jq  or  sudo dnf install jq" >&2
     exit 1
   fi
 fi

--- a/skills/health/scripts/collect-data.sh
+++ b/skills/health/scripts/collect-data.sh
@@ -49,6 +49,19 @@ count_local_skills() {
   printf '%s\n' "${count:-0}"
 }
 
+resolve_symlink() {
+  readlink -f "$1" 2>/dev/null && return
+  # macOS fallback: resolve symlink chain manually
+  local target="$1"
+  while [ -L "$target" ]; do
+    local dir
+    dir=$(cd "$(dirname "$target")" && pwd -P)
+    target=$(readlink "$target")
+    case "$target" in /*) ;; *) target="$dir/$target" ;; esac
+  done
+  printf '%s\n' "$target"
+}
+
 count_file_lines() {
   local file="$1"
   if [ -f "$file" ]; then
@@ -490,7 +503,7 @@ for DIR in "$P/.claude/skills" "$HOME/.claude/skills"; do
     IS_LINK="no"; LINK_TARGET=""
     SKILL_DIR=$(dirname "$f")
     if [ -L "$SKILL_DIR" ]; then
-      IS_LINK="yes"; LINK_TARGET=$(readlink -f "$SKILL_DIR")
+      IS_LINK="yes"; LINK_TARGET=$(resolve_symlink "$SKILL_DIR")
     fi
     echo "path=$f words=$WORDS symlink=$IS_LINK target=$LINK_TARGET"
   done < <(list_skill_files "$DIR")
@@ -521,7 +534,7 @@ for DIR in "$P/.claude/skills" "$HOME/.claude/skills"; do
   [ -d "$DIR" ] || continue
   find "$DIR" -maxdepth 1 -type l 2>/dev/null | while IFS= read -r link; do
     _PROVENANCE_FOUND=1
-    TARGET=$(readlink -f "$link")
+    TARGET=$(resolve_symlink "$link")
     echo "link=$(basename "$link") target=$TARGET"
     GIT_ROOT=$(git -C "$TARGET" rev-parse --show-toplevel 2>/dev/null || echo "")
     if [ -n "$GIT_ROOT" ]; then


### PR DESCRIPTION
## Summary

- **collect-data.sh**: `readlink -f` is GNU-only and crashes on macOS when symlinked skill directories exist (`set -e` kills the script). Adds `resolve_symlink()` using the same try-Linux-then-macOS pattern as `cache_file_mtime` in `statusline.sh`.
- **setup-statusline.sh**: jq install error message now shows instructions for macOS, Debian, and Fedora instead of only `brew install jq`.

## Test plan

- [x] `bash -n` passes on both modified scripts
- [x] `make test` passes (all smoke tests green)