### PR TITLE
docs: ensure rules directory exists before curl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Claude corrects your mistakes in place, tagging each one with its pattern name s
 
 ```bash
 # Claude Code
-curl -fsSL https://raw.githubusercontent.com/tw93/Waza/main/rules/english.md -o ~/.claude/rules/english.md
+mkdir -p ~/.claude/rules && curl -fsSL https://raw.githubusercontent.com/tw93/Waza/main/rules/english.md -o ~/.claude/rules/english.md
 
 # Codex
 curl -fsSL https://raw.githubusercontent.com/tw93/Waza/main/rules/english.md >> ~/.codex/AGENTS.md


### PR DESCRIPTION
Fix install command in README: add mkdir -p ~/.claude/rules before curl so the command doesn't fail when the directory doesn't exist