### PR TITLE
feat: add /refactor skill for clean code restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each engineering habit gets an installed skill. In Claude Code, type the slash c
 | [`/think`](skills/think/SKILL.md) | Before building anything new | Challenges the problem, pressure-tests the design, validates architecture before any code is written. |
 | [`/design`](skills/design/SKILL.md) | Building frontend interfaces | Produces distinctive UI with a committed aesthetic direction, not generic defaults. |
 | [`/check`](skills/check/SKILL.md) | After a task, before merging | Reviews the diff, auto-fixes safe issues, flags destructive commands, verifies with evidence. |
+| [`/refactor`](skills/refactor/SKILL.md) | Cleaning up code | Restructures existing code to improve readability, reduce complexity, and apply DRY without changing external behavior. |
 | [`/hunt`](skills/hunt/SKILL.md) | Any bug or unexpected behavior | Systematic debugging. Root cause confirmed before any fix is applied. |
 | [`/write`](skills/write/SKILL.md) | Writing or editing prose | Rewrites prose to sound natural in Chinese and English. Cuts stiff, formulaic phrasing. |
 | [`/learn`](skills/learn/SKILL.md) | Diving into an unfamiliar domain | Six-phase research workflow: collect, digest, outline, fill in, refine, then self-review and publish. |

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: refactor
+description: "Restructures and cleans up existing code without changing its external behavior. Focuses on readability, DRY principles, complexity reduction, and naming conventions."
+when_to_use: "refactor this, clean up this code, extract method, simplify this, reduce complexity, make it readable, 重构, 清理代码"
+metadata:
+  version: "1.0.0"
+---
+
+# Refactor: Restructure Without Breaking
+
+Prefix your first line with 🧹 inline, not as its own paragraph.
+
+Refactoring changes how code is written, not what it does. Do not add new features, change external APIs, or alter behavior during a refactor unless explicitly approved.
+
+## Before You Start
+
+- Confirm the working path and locate the target file(s).
+- Verify if automated tests exist for the target code. If none exist, flag this immediately. "There are no tests covering this code. Refactoring is high-risk. Proceed anyway?" Wait for approval.
+- Run the code or tests if possible to ensure a baseline working state.
+
+## Identify the Smell
+
+Do not blindly rewrite code. Identify the specific "code smell" you are targeting first.
+State the problem clearly:
+- Is the function too long? (Extract Method)
+- Are there duplicate code blocks? (DRY)
+- Is cyclomatic complexity too high (too many `if/else` or loops)? (Simplify Conditionals)
+- Are variable names confusing or misleading? (Rename)
+
+Give one recommended refactoring approach in 2-3 sentences. Name the smell and the technique to fix it.
+
+## Execution Rules
+
+1. **One Thing At A Time:** Apply exactly one primary refactoring technique at a time. Do not mix extracting methods with renaming variables across the entire file unless it's a very small script.
+2. **Incremental Changes:** For files larger than 100 lines, do not attempt a full rewrite in one go. Refactor one logical block, verify it, then move to the next.
+3. **Preserve Comments:** Do not delete existing comments unless the refactor makes them completely irrelevant. Update comments if the logic structure changes.
+4. **No Feature Creep:** If you spot a bug or a missing feature while refactoring, note it down but **do not fix it** during the refactoring pass. Refactoring and bug-fixing are separate tasks.
+
+## Gotchas
+
+| What happened | Rule |
+|---------------|------|
+| Changed a public method signature without updating callers | Never change external APIs during a standard refactor unless asked |
+| Added error handling that wasn't there before | No feature creep. Keep the exact same behavior, including failures |
+| Rewrote a 500-line file in one pass and broke it | Refactor incrementally. Extract one piece at a time |
+| Refactored code without tests and introduced a subtle bug | Always warn if tests are missing before starting |
+
+## Output
+
+**Refactoring Summary:**
+- **Target:** The file or function that was refactored.
+- **Smell Identified:** What was wrong (e.g., duplicated logic).
+- **Techniques Applied:** What was done (e.g., extracted to a helper function).
+- **Risk Level:** Low/Medium/High (based on test coverage and complexity).
+
+After completing the refactor, ask the user to verify the behavior or run tests before continuing. Stop.


### PR DESCRIPTION
## What does this PR do?
Adds a new `/refactor` skill to Waza to handle systematic code restructuring without changing external behavior.

## Why is it needed?
When asked to clean up code, AI models often accidentally introduce subtle bugs, change public API signatures, or quietly add new features. The `/refactor` skill enforces strict constraints to prevent this, focusing the model entirely on structural improvements (readability, DRY, complexity reduction).

**Key rules enforced by this skill:**
- **No Feature Creep:** Strictly forbids adding new functionality or fixing bugs during a refactor pass.
- **Incremental Changes:** Requires the model to tackle large files block-by-block rather than attempting a full, brittle rewrite.
- **Test Awareness:** Forces the model to warn the user and seek approval before refactoring code that lacks automated test coverage.
- **Problem Identification:** Requires naming the specific "code smell" (e.g., duplicate logic, high cyclomatic complexity) before executing a fix.

## Changes
- `[+]` Created `skills/refactor/SKILL.md` playbook and gotchas.
- `[+]` Updated `README.md` to include `/refactor` in the skills table.
