### PR TITLE
fix(marketplace): add bundle entry to install Waza as dispatcher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,14 @@
   },
   "plugins": [
     {
+      "name": "waza",
+      "description": "Install Waza as a single dispatcher skill (matches the default `npx skills add tw93/Waza` behavior). The top-level SKILL.md routes intents to the eight sub-skills (think, check, hunt, design, read, write, learn, health) and preserves the Path Resolution directive plus disambiguation rules. Recommended for users who want the whole bundle.",
+      "version": "3.18.0",
+      "category": "development",
+      "source": "./",
+      "homepage": "https://github.com/tw93/Waza"
+    },
+    {
       "name": "health",
       "description": "Audits the full six-layer Claude Code config stack when Claude ignores instructions, behaves inconsistently, hooks malfunction, or MCP servers need auditing. Flags issues by severity. Not for debugging code or reviewing PRs.",
       "version": "3.16.0",


### PR DESCRIPTION
## Why

The current `marketplace.json` exposes only the eight sub-skills as flat plugins (each with `source: "./skills/<name>"`). This means Plugin-path users (`/plugin install ...`) are forced into a flat install, which contradicts the dispatcher philosophy that the top-level `SKILL.md` and the README are built around.

By contrast, the default `npx skills add tw93/Waza` install gives users the full bundle: top-level dispatcher + eight sub-skills + Path Resolution directive + disambiguation rules. Plugin-path users today cannot get this experience — they can only install one sub-skill at a time.

## What flat install loses

When sub-skills are installed without the top-level `SKILL.md`:

1. **Path Resolution is bypassed.** The top-level `SKILL.md` contains:
   > In this distribution, sub-skill scripts live at `skills/{name}/scripts/`. Resolve all relative paths from this file's directory, not from `$HOME/.agents/`.
   
   This directive is what overrides the `${CLAUDE_SKILL_DIR:-$HOME/.agents/skills/<name>}` fallback baked into `/check`, `/health`, and `/read`'s scripts. Without it, those scripts resolve paths against `$HOME/.agents/skills/<name>/scripts/...` and fail when the skill is installed elsewhere.

2. **Dispatcher routing is lost.** The top-level `SKILL.md` contains an intent → sub-skill routing table that disambiguates overlapping triggers (e.g., "判断一下" → `/think` Evaluation Mode vs `/hunt` for error context).

3. **Cross-skill chaining notes are lost.** For example, `/learn` Phase 1 explicitly calls `/read` for fetch; without the bundle, this chain has no shared context.

## What this PR does

Adds **one** bundle entry at the top of the `plugins` array:

```json
{
  "name": "waza",
  "source": "./",
  ...
}
```

This makes the whole repository installable as a single Plugin-path entry, matching what `npx skills add tw93/Waza` does today.

## What is preserved

- **All eight existing flat entries remain unchanged**, so anyone who deliberately wants just `/check` or `/think` can still install it standalone.
- **No script changes**, no behavioral changes to any sub-skill.
- **`npx skills` install path is unaffected** (it doesn't read `marketplace.json`).

## Reference

The active production sample of this pattern is [`vue-skills-bundle`](https://github.com/tonghohin/vue-skills-bundle/blob/main/.claude-plugin/marketplace.json), which uses the same "bundle entry + individual sub-plugin entries" structure.