### PR TITLE
fix(marketplace): restore /plugin install path and namespace per-skill entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,68 +8,92 @@
   },
   "plugins": [
     {
-      "name": "health",
+      "name": "waza",
+      "description": "Installs the full Waza toolkit. Registers all eight skills under the waza namespace, callable as /waza:think, /waza:check, /waza:hunt, /waza:design, /waza:read, /waza:write, /waza:learn, and /waza:health. Not for users who only want one skill — install a waza-<skill>@waza entry instead.",
+      "version": "3.12.2",
+      "category": "development",
+      "source": "./",
+      "homepage": "https://github.com/tw93/Waza"
+    },
+    {
+      "name": "waza-health",
       "description": "Runs a budget-aware audit of the Claude Code config stack when Claude ignores instructions, behaves inconsistently, hooks malfunction, MCP servers need auditing, or users ask why /health used many tokens. Flags issues by severity. Not for debugging code or reviewing PRs.",
       "version": "3.17.0",
       "category": "development",
       "source": "./skills/health",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "think",
+      "name": "waza-think",
       "description": "Turns rough ideas into approved, decision-complete plans with validated structure before writing code. Covers new features, architecture decisions, and value judgments about whether to build, keep, or remove something. Not for bug fixes or small edits.",
       "version": "3.17.0",
       "category": "development",
       "source": "./skills/think",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "check",
+      "name": "waza-check",
       "description": "Reviews code diffs and release-ready changes after implementation, extracts project-specific constraints from repository context, auto-fixes safe issues, and drives approved release, publish, push, release-reaction, and issue/PR follow-through. Also triages issues and PRs when the user mentions them. Not for exploring ideas or debugging.",
       "version": "3.20.0",
       "category": "development",
       "source": "./skills/check",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "hunt",
+      "name": "waza-hunt",
       "description": "Finds root cause of errors, crashes, regressions, screenshot-reported defects, unexpected behavior, and failing tests before applying any fix. Not for code review or new features.",
       "version": "3.19.0",
       "category": "development",
       "source": "./skills/hunt",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "design",
+      "name": "waza-design",
       "description": "Produces distinctive, production-grade UI for any component, page, or visual interface. Handles screenshot-driven iteration when the user sends an image with a visual complaint. Not for backend logic or data pipelines.",
       "version": "3.19.0",
       "category": "development",
       "source": "./skills/design",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "read",
+      "name": "waza-read",
       "description": "Fetches any URL or PDF as clean Markdown for reading, quoting, citation, or downstream work. Handles paywalls, JS-heavy pages, X/Twitter, and Chinese platforms via proxy cascade. Not for local text files already in the repo.",
       "version": "3.14.0",
       "category": "development",
       "source": "./skills/read",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "write",
+      "name": "waza-write",
       "description": "Strips AI writing patterns and rewrites prose to sound natural in Chinese or English. Only activates on explicit writing or editing requests. Not for code comments, commit messages, or inline docs.",
       "version": "3.18.0",
       "category": "development",
       "source": "./skills/write",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     },
     {
-      "name": "learn",
+      "name": "waza-learn",
       "description": "Runs a six-phase research workflow to turn unfamiliar domains or collected sources into publish-ready output. Not for quick lookups or single-file reads.",
       "version": "3.15.0",
       "category": "development",
       "source": "./skills/learn",
-      "homepage": "https://github.com/tw93/Waza"
+      "homepage": "https://github.com/tw93/Waza",
+      "skills": ["./"],
+      "strict": false
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -106,17 +106,17 @@ smoke-verify-skills:
 		fi; \
 		grep -q 'INVALID FRONTMATTER' "$$tmpdir/frontmatter.err"; \
 		copy_repo "$$tmpdir/repo2"; \
-		python3 -c "import json; p='$$tmpdir/repo2/.claude-plugin/marketplace.json'; d=json.load(open(p)); d['plugins'].append({'name':'ghost','description':'x','version':'1.0.0','category':'development','source':'./skills/ghost','homepage':'https://example.com'}); open(p,'w').write(json.dumps(d, indent=2) + '\n')"; \
+		python3 -c "import json; p='$$tmpdir/repo2/.claude-plugin/marketplace.json'; d=json.load(open(p)); d['plugins'].append({'name':'waza-ghost','description':'x','version':'1.0.0','category':'development','source':'./skills/ghost','homepage':'https://example.com'}); open(p,'w').write(json.dumps(d, indent=2) + '\n')"; \
 		if (cd "$$tmpdir/repo2" && ./scripts/verify-skills.sh >"$$tmpdir/market.out" 2>"$$tmpdir/market.err"); then \
 			echo "verify-skills should reject marketplace-only entries"; exit 1; \
 		fi; \
 		grep -q 'MISSING SKILL DIRECTORY: ghost' "$$tmpdir/market.err"; \
 		copy_repo "$$tmpdir/repo3"; \
-		python3 -c "import json; p='$$tmpdir/repo3/.claude-plugin/marketplace.json'; d=json.load(open(p)); [entry.update({'source':'./skills/read'}) for entry in d['plugins'] if entry['name']=='check']; open(p,'w').write(json.dumps(d, indent=2) + '\n')"; \
+		python3 -c "import json; p='$$tmpdir/repo3/.claude-plugin/marketplace.json'; d=json.load(open(p)); [entry.update({'source':'./skills/read'}) for entry in d['plugins'] if entry['name']=='waza-check']; open(p,'w').write(json.dumps(d, indent=2) + '\n')"; \
 		if (cd "$$tmpdir/repo3" && ./scripts/verify-skills.sh >"$$tmpdir/source.out" 2>"$$tmpdir/source.err"); then \
 			echo "verify-skills should reject wrong source paths"; exit 1; \
 		fi; \
-		grep -q 'WRONG SOURCE: check' "$$tmpdir/source.err"; \
+		grep -q 'WRONG SOURCE: waza-check' "$$tmpdir/source.err"; \
 		copy_repo "$$tmpdir/repo4"; \
 		python3 -c "from pathlib import Path; p=Path('$$tmpdir/repo4/skills/check/SKILL.md'); p.write_text(p.read_text() + '\n[broken](missing-target.md)\n')"; \
 		if (cd "$$tmpdir/repo4" && ./scripts/verify-skills.sh >"$$tmpdir/link.out" 2>"$$tmpdir/link.err"); then \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,21 @@ Most users should install Waza globally, so the same skills are available in eve
 npx skills add tw93/Waza -a claude-code -g -y
 ```
 
-This installs the individual `/think`, `/design`, `/check`, `/hunt`, `/write`, `/learn`, `/read`, and `/health` skills.
+This installs the individual `/think`, `/design`, `/check`, `/hunt`, `/write`, `/learn`, `/read`, and `/health` skills. Install just one with `--skill`:
+
+```bash
+npx skills add tw93/Waza --skill think -a claude-code -g -y
+```
+
+**Claude Code plugin marketplace**
+
+Install all skills via the `waza` bundle, or just one via a `waza-<skill>` entry:
+
+```bash
+/plugin marketplace add tw93/Waza
+/plugin install waza@waza
+/plugin install waza-think@waza
+```
 
 **Codex**
 
@@ -59,11 +73,10 @@ This installs the individual `/think`, `/design`, `/check`, `/hunt`, `/write`, `
 npx skills add tw93/Waza -a codex -g -y
 ```
 
-**Claude Code plugin marketplace**
+Install just one with `--skill`:
 
 ```bash
-/plugin marketplace add tw93/Waza
-/plugin install think@waza
+npx skills add tw93/Waza --skill think -a codex -g -y
 ```
 
 **Claude Desktop**

--- a/scripts/verify-skills.sh
+++ b/scripts/verify-skills.sh
@@ -87,8 +87,17 @@ plugins = marketplace.get("plugins")
 if not isinstance(plugins, list):
     fail("INVALID MARKETPLACE: plugins must be a list")
 
+# Marketplace shape:
+#   - One bundle entry: name == "waza", source == "./". Auto-discovers all
+#     skills/<dir>/SKILL.md and registers them under the waza namespace
+#     (/waza:think, /waza:check, ...).
+#   - Per-skill entries: name == "waza-<skill>", source == "./skills/<skill>".
+#     Each registers a single skill, callable as /waza-<skill>:<skill>.
+# Per-skill entries are keyed by skill_name (the dir under skills/) so version
+# and description checks line up with skill_versions / skill_descriptions.
 market_versions: dict[str, str] = {}
 market_descriptions: dict[str, str] = {}
+seen_names: set[str] = set()
 for entry in plugins:
     if not isinstance(entry, dict):
         fail("INVALID MARKETPLACE: plugin entry must be an object")
@@ -100,15 +109,40 @@ for entry in plugins:
         fail("INVALID MARKETPLACE: every plugin needs name and version")
     if not description:
         fail(f"MISSING DESCRIPTION: marketplace plugin {name}")
-    if name in market_versions:
+    if name in seen_names:
         fail(f"DUPLICATE MARKETPLACE ENTRY: {name}")
+    seen_names.add(name)
+
     if name == "waza":
-        fail("MARKETPLACE BUNDLE REMOVED: do not add a waza entry that points at the repository root")
-    expected_source = f"./skills/{name}"
+        # Duplicate bundle is already caught by the generic seen_names check
+        # above (any second entry with the same name fails first).
+        if source != "./":
+            fail(f"WRONG BUNDLE SOURCE: source={source!r} expected='./'")
+        continue
+
+    if not name.startswith("waza-"):
+        fail(
+            f"INVALID PLUGIN NAME: {name!r} must be 'waza' (bundle) or "
+            f"'waza-<skill>' (per-skill entry)"
+        )
+    skill_name = name.removeprefix("waza-")
+    if not skill_name:
+        fail(
+            f"INVALID PLUGIN NAME: {name!r} has an empty <skill> suffix; "
+            f"per-skill entries must be named 'waza-<skill>' with a non-empty skill name"
+        )
+    expected_source = f"./skills/{skill_name}"
     if source != expected_source:
         fail(f"WRONG SOURCE: {name} source={source!r} expected={expected_source!r}")
-    market_versions[name] = version
-    market_descriptions[name] = description
+    market_versions[skill_name] = version
+    market_descriptions[skill_name] = description
+
+if "waza" not in seen_names:
+    fail(
+        "MISSING BUNDLE ENTRY: marketplace.json must include a 'waza' bundle entry "
+        "(name=\"waza\", source=\"./\") so /plugin install waza@waza registers "
+        "all skills under the waza namespace"
+    )
 
 missing_from_market = sorted(set(skill_versions) - set(market_versions))
 if missing_from_market:


### PR DESCRIPTION
# fix(marketplace): restore /plugin install path and namespace per-skill entries

## 背景

v3.12.2 之后，`/plugin install` 这条路径处于静默失败状态：marketplace add 和 plugin install 命令都报告成功，但装完之后没有任何 slash 命令变得可用。这个 PR 让 marketplace plugin 路径完整可用，并在 README 里补全两条主流 host（Claude Code、Codex）的安装范例。

这次修复的思路来自 tw93/Kami#16（已合并）。那条 PR 解决了 Kami 单 skill 扁平仓库下同类的 `/plugin install` 路径校验问题：把字段从 `plugin.json` 移到 marketplace entry，加上 `skills: ["./"]` + `strict: false`，让 Anthropic plugin loader 找到 plugin 根的 `SKILL.md`。同一套字段组合在那条 PR 上验证有效；本 PR 把它泛化到 Waza 的多 skill 拓扑（bundle + 8 个 per-skill 入口），并配套处理命名空间和 verify 守卫。

## 现象

```
/plugin marketplace add tw93/Waza
/plugin install think@waza
✓ Installed think. Run /reload-plugins to apply.
/reload-plugins
Reloaded: ... plugins ... skills ...
```

命令报告成功，reload 不报错，但 `/help` 里没有任何新增 slash 命令，`/think:think`、`/think` 都不存在。`/plugin install check@waza` 等其余 7 条 per-skill 入口同样表现。

## 诊断

### 1. 8 个独立入口装上后注册 0 个 skill

`marketplace.json` 里 8 条 per-skill 入口都声明 `source: "./skills/<name>"`，但每个目录都是扁平的：`SKILL.md` 直接在那一层下，下面没有再嵌套 `.claude-plugin/plugin.json`，也没有 `skills/<name>/SKILL.md`。

Claude Code 默认的 plugin 自动发现规则只扫 `<plugin_root>/skills/<name>/SKILL.md` 和 `<plugin_root>/commands/*.md`。这些 per-skill plugin 装上后发现机制找不到任何 skill 文件，注册数量为 0。安装命令本身不报错（marketplace 入口存在），但加载阶段静默失败。

### 2. bundle 入口在 v3.12.2 被一并误删

v3.12.2 的 commit `c9851f6 fix: keep desktop dispatcher out of source root` 一次做了两件事，把它们的对错分开看：

**(a) 删除仓库根的 `SKILL.md`**：方向正确。

仓库根曾经存在的 dispatcher `SKILL.md` 让 `npx skills add tw93/Waza` 默认只扫到根那一层就停。npx CLI 默认找到根 SKILL.md 就装它，不会继续往子目录扫。issue #44 报告的"升级后只剩 `/waza`"就是这条机制的副产品，多 skill 仓库不应该有根 SKILL.md。删掉它（动态生成逻辑搬到 `package-skill.sh`），npx 默认行为回到扫子目录，能正常装出 8 个 skill。

**(b) 同时删除 marketplace.json 里的 `waza` bundle 入口**：连带误删。

release notes 第 4 条原话：

> Removed the `waza@waza` root bundle entry; marketplace installs remain available through individual entries such as `think@waza`.

这条结论建立在一个隐含前提上：bundle 入口"只服务于根 dispatcher SKILL.md，根 SKILL.md 没了 bundle 也没用"。

这个前提不准确。bundle 入口的 `source: "./"` 配合仓库已经存在的 8 个 `skills/<name>/SKILL.md` 子目录，自动发现机制会注册 8 个 skill 到 `waza` namespace 下：`/waza:think`、`/waza:check`、`/waza:hunt`、`/waza:design`、`/waza:read`、`/waza:write`、`/waza:learn`、`/waza:health`。dispatcher SKILL.md 对这条路径并非必需，bundle 不依赖根 SKILL.md，连带它一起删除是无意之举。

release notes 同段说"marketplace installs remain available through individual entries such as `think@waza`"也不成立。实测 v3.12.2 主干上 `think@waza` 装出来注册 0 skill，就是诊断 1 描述的失败模式。

### 3. 命名空间为什么必须用 `waza-<skill>` 前缀

Claude Code plugin 的调用规则是 `<plugin_name>:<skill_name>`，每个 marketplace 入口的 `name` 在 plugin 系统下都是一个**独立 plugin**，有独立 namespace、独立安装、独立卸载。三种入口的命名结果：

- **bundle 入口** `name: "waza"`：装 `/plugin install waza@waza` 后，8 个子 skill 落在 `/waza:` namespace 下（`/waza:think`、`/waza:check` 等）。namespace 直接就叫 `waza`，不需要额外前缀。
- **per-skill 入口保持原 skill 名**（`think`、`check`...）：plugin name 直接是 `think`，调用名变成 `/think:think`，同字重复。这种裸名在用户全局 plugin 列表里很容易和其他来源的同名 plugin 撞名（Anthropic 官方插件、其他社区插件都可能用同样的名字）。
- **per-skill 入口加 `waza-` 前缀**（`waza-think`、`waza-check`...）：plugin name 是 `waza-think`，调用名变成 `/waza-think:think`，和 bundle 的 `/waza:` 同属 waza 命名空间。用户记一种规则就够，全局也不容易撞名。

bundle 不需要前缀因为它本身就叫 `waza`；per-skill 必须前缀，因为每条都是独立 plugin，需要稳定的命名空间避免冲突。

## 修复

### `marketplace.json`

- 恢复 `name: "waza"`、`source: "./"` 的 bundle 入口（`version: "3.12.2"`）
- 8 个 per-skill 入口的 `name` 改成 `waza-<skill>`：`waza-think`、`waza-check`、`waza-hunt`、`waza-design`、`waza-read`、`waza-write`、`waza-learn`、`waza-health`
- 每个 per-skill 入口加 `skills: ["./"]` + `strict: false`

`skills: ["./"]` 告诉 plugin loader："SKILL.md 直接位于 plugin 根，而不是 `skills/<name>/` 子目录"。
`strict: false` 告诉 Claude Code："marketplace 入口本身就是完整 plugin 定义，不需要额外的 `plugin.json`"。

两个字段都是官方 plugin reference 明确支持的写法：

- `skills: ["./"]` — https://code.claude.com/docs/en/plugins-reference#path-behavior-rules
- `strict: false` — https://code.claude.com/docs/en/plugin-marketplaces#strict-mode

### `scripts/verify-skills.sh`

marketplace 校验段重写以支持新拓扑：

- bundle 入口现在是**必须存在**的（一键全装是项目契约的一部分），其 source 必须严格为 `"./"`
- per-skill 入口必须命名为 `waza-<skill>` 且 source 必须为 `./skills/<skill>`，空后缀（如 `name: "waza-"`）会被独立守卫拦下
- version 和 description 跨表对齐检查的 keying 改为基于 skill 目录名（从 plugin name 移除 `waza-` 前缀派生）

旧守卫 `if name == "waza": fail("MARKETPLACE BUNDLE REMOVED: ...")` 被删除，它和恢复 bundle 这条主线直接冲突。它原本要防止的（dispatcher 复活进源码树）现在由 bundle 入口 source 锁死为 `"./"` 这条新守卫继续兜底。

README 默认 npx install 命令的 grep guard 不动。

### `Makefile`

`smoke-verify-skills` target 的两个 fixture 同步更新到新命名拓扑：repo2 fixture 的 plugin name 从 `ghost` 改成 `waza-ghost`（让它先通过 `INVALID PLUGIN NAME` 守卫，再被 `MISSING SKILL DIRECTORY: ghost` 拦下，保持 fixture 原意图），repo3 fixture 找 `name == 'check'` 改成 `name == 'waza-check'`，对应 grep keyword 改为 `WRONG SOURCE: waza-check`。其他 4 个 fixture（frontmatter / broken link / RESOLVER / pipe）不受拓扑变化影响，保持不动。

### `README.md`

在已有的 `## Install and Update` 段落里：

- **Claude Code direct slash commands**：补一条单装范例 `npx skills add tw93/Waza --skill think -a claude-code -g -y`
- **Claude Code plugin marketplace**：把原来单条的 `/plugin install think@waza` 改成 bundle + per-skill 双入口，前面加一句 prose 解释"`waza` 装全部、`waza-<skill>` 装单个"
- **Codex**：补一条单装范例 `--skill think`

默认 npx 命令保留 v3.12.2 的形态（不带 `--full-depth`）。v3.12.2 删除根 SKILL.md 后，npx CLI 默认就会扫到 `skills/<name>/SKILL.md`。本地用 `npx skills add tw93/Waza -l` 做 dry-run，带和不带 `--full-depth` 两种都报告 `Found 8 skills`。

## 验证

四条安装路径全部端到端测试通过，每条都从 clean uninstall + marketplace remove 起步：

| # | 路径 | 命令 | 结果 |
|---|---|---|---|
| 1 | 本地仓库 marketplace | `/plugin marketplace add /Users/cyrus/projects/forks/Waza` + `/plugin install waza@waza` | OK，8 个 `/waza:*` 全部注册 |
| 2a | 修复分支远程 marketplace（bundle）| `/plugin marketplace add qishaoyumu/Waza@fix/plugin-install-path` + `/plugin install waza@waza` | OK，`/waza:think` 触发 skill，base dir `~/.claude/plugins/cache/waza/waza/3.12.2/skills/think` |
| 2b | 远程 marketplace + 单装 think | `/plugin install waza-think@waza` | OK，`/waza-think:think` 触发 skill，base dir `~/.claude/plugins/cache/waza/waza-think/3.17.0` |
| 2c | 远程 marketplace + 单装 check | `/plugin install waza-check@waza` | OK，`/waza-check:check` 注册 |
| 2d | 反向（v3.12.2 已不存在的入口）| `/plugin install think@waza` | 按预期失败：`Plugin "think" not found in marketplace "waza"` |
| 3 | Claude Desktop ZIP | 本地 `bash scripts/package-skill.sh` 重打 + 上传 dist/waza.zip | OK，安装并调用 skill 表现与 v3.12.2 一致 |
| 4a | npx skills 全装 | `npx skills add tw93/Waza -a claude-code -g -y` | OK，dry-run 报告 `Found 8 skills` |
| 4b | npx skills 单装 | `npx skills add tw93/Waza --skill think -a claude-code -g -y` | OK，dry-run 显示仅 `think` 入选 |

`/reload-plugins` 在每条路径下都报 0 error。`bash scripts/verify-skills.sh` 通过（rc=0）。

### 本地闭环测试（16 fixtures，不进 PR）

另起一份 16 case 闭环测试覆盖 PR 涉及的全部 fail 路径：baseline、bundle 缺失/重复/source 错、per-skill 缺前缀/空后缀/source 错位、缺 entry、多余 entry、version/description mismatch、plugin 缺 name/version/description、README 缺默认 npx 命令。15 条 fail case 全部按预期触发对应 keyword，1 条 baseline PASS。

### Claude Desktop ZIP 不受 PR 影响的证据

```bash
unzip -l dist/waza.zip | grep -i "marketplace"   # 输出 none
```

`.claude-plugin/` 整个目录被 `package-skill.sh` 的 awk filter 排除，zip 里没有 `marketplace.json`，根 dispatcher SKILL.md 仍然仅在 `make package` 时动态生成。

## 不影响的范围

- **npx skills add CLI 路径**：不读 `marketplace.json`，仍按 v3.12.2 的源码布局扫到 `skills/<name>/SKILL.md`
- **Claude Desktop ZIP 路径**：见上文验证，zip 内容与 v3.12.2 一致
- **`skills/<name>/SKILL.md` 内容和 frontmatter**：完全未动
- **`scripts/package-skill.sh`**：完全未动
- **verify-skills.sh 中其他守卫**：SKILL.md schema、RESOLVER.md 覆盖、description 长度、root-SKILL.md 守卫、README install command 守卫、English coaching 守卫，全部未动

## Scope

```
.claude-plugin/marketplace.json | 56 +++++++++++++++++++++++++++++------------
Makefile                        |  6 ++---
README.md                       | 21 +++++++++++++---
scripts/verify-skills.sh        | 44 ++++++++++++++++++++++++++++----
4 files changed, 99 insertions(+), 28 deletions(-)
```

单 commit，分支 `fix/plugin-install-path` 基于 upstream/main HEAD `a1acdba`，0 behind / 1 ahead。
