### PR TITLE
fix: preserve statusline high-water across stale sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,26 @@ smoke-statusline:
 	tmpdir=$$(mktemp -d); \
 	json1='{"context_window":{"current_usage":{"input_tokens":10},"context_window_size":100},"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":2000000000},"seven_day":{"used_percentage":34,"resets_at":2000003600}}}'; \
 	json2='{"context_window":{"current_usage":{"input_tokens":20},"context_window_size":100}}'; \
+	json_high='{"context_window":{"current_usage":{"input_tokens":30},"context_window_size":100},"rate_limits":{"five_hour":{"used_percentage":61,"resets_at":2000000000},"seven_day":{"used_percentage":63,"resets_at":2000003600}}}'; \
+	json_low='{"context_window":{"current_usage":{"input_tokens":40},"context_window_size":100},"rate_limits":{"five_hour":{"used_percentage":1,"resets_at":2000000000},"seven_day":{"used_percentage":61,"resets_at":2000003600}}}'; \
 	printf '%s' "$$json1" | HOME="$$tmpdir" bash scripts/statusline.sh >/dev/null; \
 	printf '%s' "$$json2" | HOME="$$tmpdir" bash scripts/statusline.sh >"$$tmpdir/out2"; \
 	printf '%s' "$$json2" | HOME="$$tmpdir" bash scripts/statusline.sh >"$$tmpdir/out3"; \
 	grep -q '"used_percentage": 12' "$$tmpdir/.cache/waza-statusline/last.json"; \
+	printf '%s' "$$json_high" | HOME="$$tmpdir" bash scripts/statusline.sh >/dev/null; \
+	printf '%s' "$$json_low" | HOME="$$tmpdir" bash scripts/statusline.sh >"$$tmpdir/out4"; \
 	grep -q '5h:' "$$tmpdir/out2"; \
 	grep -q '7d:' "$$tmpdir/out2"; \
 	grep -q '12%' "$$tmpdir/out2"; \
 	grep -q '34%' "$$tmpdir/out3"; \
+	grep -q '61%' "$$tmpdir/out4"; \
+	grep -q '63%' "$$tmpdir/out4"; \
+	tmpdir2=$$(mktemp -d); \
+	mkdir -p "$$tmpdir2/.cache/waza-statusline"; \
+	printf '%s\n' '{"seven_day":{"used_percentage":63,"resets_at":2000003600}}' > "$$tmpdir2/.cache/waza-statusline/highwater.json"; \
+	printf '%s' "$$json1" | HOME="$$tmpdir2" bash scripts/statusline.sh >"$$tmpdir2/out"; \
+	grep -q '12%' "$$tmpdir2/out"; \
+	grep -q '63%' "$$tmpdir2/out"; \
 	echo "statusline smoke: ok"
 
 smoke-statusline-installer:

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -5,7 +5,11 @@
 
 CACHE_DIR="$HOME/.cache/waza-statusline"
 CACHE_FILE="$CACHE_DIR/last.json"
+HIGHWATER_FILE="$CACHE_DIR/highwater.json"
+HIGHWATER_LOCK_DIR="$CACHE_DIR/highwater.lock"
 CACHE_MAX_AGE=21600  # 6 hours: one full rate_limit window
+HIGHWATER_LOCK_MAX_AGE=10
+HIGHWATER_RESET_SKEW_MAX=7200  # tolerate session jitter, reject crossed windows
 
 input=$(cat)
 
@@ -39,6 +43,143 @@ cache_file_mtime() {
   printf '%s\n' "${ts:-0}"
 }
 
+is_uint() {
+  case "$1" in
+    ''|null) return 1 ;;
+    *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+acquire_highwater_lock() {
+  mkdir -p "$CACHE_DIR" 2>/dev/null || return 1
+  local attempts=0 lock_mtime now
+  while [ "$attempts" -lt 5 ]; do
+    attempts=$((attempts + 1))
+    if mkdir "$HIGHWATER_LOCK_DIR" 2>/dev/null; then
+      return 0
+    fi
+    lock_mtime=$(cache_file_mtime "$HIGHWATER_LOCK_DIR")
+    now=$(date +%s)
+    if [ $((now - lock_mtime)) -gt "$HIGHWATER_LOCK_MAX_AGE" ]; then
+      rmdir "$HIGHWATER_LOCK_DIR" 2>/dev/null || true
+      continue
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+release_highwater_lock() {
+  rmdir "$HIGHWATER_LOCK_DIR" 2>/dev/null || true
+}
+
+read_highwater() {
+  hw_5h_pct=""
+  hw_5h_reset=""
+  hw_7d_pct=""
+  hw_7d_reset=""
+  [ -f "$HIGHWATER_FILE" ] || return
+  hw_5h_pct=$(jq -r 'if .five_hour.used_percentage == null then "" else (.five_hour.used_percentage | round | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
+  hw_5h_reset=$(jq -r 'if .five_hour.resets_at == null then "" else (.five_hour.resets_at | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
+  hw_7d_pct=$(jq -r 'if .seven_day.used_percentage == null then "" else (.seven_day.used_percentage | round | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
+  hw_7d_reset=$(jq -r 'if .seven_day.resets_at == null then "" else (.seven_day.resets_at | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
+}
+
+apply_hw() {
+  local live_pct="$1" live_reset="$2" hw_pct="$3" hw_reset="$4"
+  local now reset_diff live_ok=0 hw_ok=0
+  now=$(date +%s)
+
+  if is_uint "$hw_reset" && [ "$hw_reset" -le "$now" ]; then
+    hw_pct=""
+    hw_reset=""
+  fi
+  if is_uint "$live_reset" && [ "$live_reset" -le "$now" ]; then
+    live_pct=""
+    live_reset=""
+  fi
+  if is_uint "$live_reset" && is_uint "$hw_reset"; then
+    reset_diff=$((live_reset - hw_reset))
+    [ "$reset_diff" -lt 0 ] && reset_diff=$((-reset_diff))
+    if [ "$reset_diff" -gt "$HIGHWATER_RESET_SKEW_MAX" ]; then
+      hw_pct=""
+      hw_reset=""
+    fi
+  fi
+
+  is_uint "$live_pct" && live_ok=1
+  is_uint "$hw_pct" && hw_ok=1
+
+  applied_pct=""
+  applied_reset=""
+  applied_hw_pct=""
+  applied_hw_reset=""
+  if [ "$live_ok" = "0" ] && [ "$hw_ok" = "0" ]; then
+    return
+  fi
+  if [ "$live_ok" = "0" ]; then
+    applied_pct="$hw_pct"
+    applied_reset="$hw_reset"
+    applied_hw_pct="$hw_pct"
+    applied_hw_reset="$hw_reset"
+    return
+  fi
+  if [ "$hw_ok" = "0" ] || [ "$live_pct" -gt "$hw_pct" ] 2>/dev/null; then
+    applied_pct="$live_pct"
+    applied_reset="$live_reset"
+    applied_hw_pct="$live_pct"
+    applied_hw_reset="$live_reset"
+    return
+  fi
+
+  applied_pct="$hw_pct"
+  applied_reset="${live_reset:-$hw_reset}"
+  applied_hw_pct="$hw_pct"
+  applied_hw_reset="$hw_reset"
+}
+
+write_highwater() {
+  is_uint "$new_hw_5h_pct" || is_uint "$new_hw_7d_pct" || return
+  mkdir -p "$CACHE_DIR" 2>/dev/null || return
+  local r5="${new_hw_5h_reset:-0}" r7="${new_hw_7d_reset:-0}"
+  is_uint "$r5" || r5=0
+  is_uint "$r7" || r7=0
+  if ! {
+    {
+      printf '{\n'
+      if is_uint "$new_hw_5h_pct"; then
+        printf '  "five_hour": {"used_percentage": %s, "resets_at": %s}' "$new_hw_5h_pct" "$r5"
+        is_uint "$new_hw_7d_pct" && printf ','
+        printf '\n'
+      fi
+      if is_uint "$new_hw_7d_pct"; then
+        printf '  "seven_day": {"used_percentage": %s, "resets_at": %s}\n' "$new_hw_7d_pct" "$r7"
+      fi
+      printf '}\n'
+    } > "${HIGHWATER_FILE}.tmp" 2>/dev/null \
+      && mv "${HIGHWATER_FILE}.tmp" "$HIGHWATER_FILE" 2>/dev/null
+  }; then
+    :
+  fi
+}
+
+apply_highwater_all() {
+  read_highwater
+
+  apply_hw "$five_pct" "$five_reset" "$hw_5h_pct" "$hw_5h_reset"
+  five_pct="$applied_pct"
+  five_reset="$applied_reset"
+  new_hw_5h_pct="$applied_hw_pct"
+  new_hw_5h_reset="$applied_hw_reset"
+
+  apply_hw "$seven_pct" "$seven_reset" "$hw_7d_pct" "$hw_7d_reset"
+  seven_pct="$applied_pct"
+  seven_reset="$applied_reset"
+  new_hw_7d_pct="$applied_hw_pct"
+  new_hw_7d_reset="$applied_hw_reset"
+}
+
 # Single jq pass for live input
 parsed=""
 [ -n "$input" ] && parsed=$(printf '%s' "$input" | jq -r "$jq_full" 2>/dev/null)
@@ -69,10 +210,25 @@ fi
 # Persist live rate_limits only when present (atomic write)
 if [ "${live_five_pct:-}" != "null" ] && [ -n "${live_five_pct:-}" ] && [ -n "$input" ]; then
   mkdir -p "$CACHE_DIR"
-  printf '%s' "$input" | jq '{rate_limits: .rate_limits}' \
-    > "${CACHE_FILE}.tmp" 2>/dev/null \
-    && mv "${CACHE_FILE}.tmp" "$CACHE_FILE" 2>/dev/null \
-    || true
+  if ! {
+    printf '%s' "$input" | jq '{rate_limits: .rate_limits}' \
+      > "${CACHE_FILE}.tmp" 2>/dev/null \
+      && mv "${CACHE_FILE}.tmp" "$CACHE_FILE" 2>/dev/null
+  }; then
+    :
+  fi
+fi
+
+new_hw_5h_pct=""
+new_hw_5h_reset=""
+new_hw_7d_pct=""
+new_hw_7d_reset=""
+if acquire_highwater_lock; then
+  apply_highwater_all
+  write_highwater
+  release_highwater_lock
+else
+  apply_highwater_all
 fi
 
 # --- Colors ---

--- a/skills/read/scripts/fetch.sh
+++ b/skills/read/scripts/fetch.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 URL="${1:?Usage: fetch.sh <url> [proxy_url]}"
 PROXY="${2:-}"
 
-# shellcheck disable=SC2329  # called indirectly via _with_retry / _try_once
+# shellcheck disable=SC2329,SC2317  # called indirectly via _with_retry / _try_once
 _curl() {
   if [ -n "$PROXY" ]; then
     https_proxy="$PROXY" http_proxy="$PROXY" curl -sfL "$@"


### PR DESCRIPTION
## Summary

Fixes a statusline rate-limit display issue where stale Claude Code sessions can report outdated lower usage and cause the active session’s 5h/7d quota display to flicker or regress.

## Changes

1. Added per-window high-water tracking for 5h and 7d rate limits, so lower stale-session values do not overwrite the highest observed usage in the current window.

2. Kept reset handling window-aware: expired high-water values are ignored, and mismatched reset windows are rejected to avoid 7d data being applied to 5h.
3. Added a small lock around high-water cache writes and smoke coverage for stale low-percent sessions.

## Verification

Tested locally for about one week; the issue no longer reproduces. 

No breaking changes and CI passes!

<img width="447" height="150" alt="Screenshot 2026-05-05 at 22 47 44" src="https://github.com/user-attachments/assets/397c063d-5018-4755-b0b1-adbc2b443146" />
