### PR TITLE
refactor(marketplace): drop skills/strict, adopt v2.1.143 auto-discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "waza",
-      "description": "Installs the full Waza toolkit. Registers all eight skills under the waza namespace, callable as /waza:think, /waza:check, /waza:hunt, /waza:design, /waza:read, /waza:write, /waza:learn, and /waza:health. For one skill, use npx skills add tw93/Waza --skill <name> while Claude Code per-skill marketplace installs are affected upstream.",
+      "description": "Installs the full Waza toolkit. Registers all eight skills under the waza namespace, callable as /waza:think, /waza:check, /waza:hunt, /waza:design, /waza:read, /waza:write, /waza:learn, and /waza:health. For one skill, use /plugin install waza-<name>@waza instead.",
       "version": "3.24.0",
       "category": "development",
       "source": "./",
@@ -21,9 +21,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/health",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-think",
@@ -31,9 +29,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/think",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-check",
@@ -41,9 +37,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/check",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-hunt",
@@ -51,9 +45,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/hunt",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-design",
@@ -61,9 +53,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/design",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-read",
@@ -71,9 +61,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/read",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-write",
@@ -81,9 +69,7 @@
       "version": "3.24.0",
       "category": "development",
       "source": "./skills/write",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     },
     {
       "name": "waza-learn",
@@ -91,9 +77,7 @@
       "version": "3.15.0",
       "category": "development",
       "source": "./skills/learn",
-      "homepage": "https://github.com/tw93/Waza",
-      "skills": ["./"],
-      "strict": false
+      "homepage": "https://github.com/tw93/Waza"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -62,14 +62,13 @@ npx skills add tw93/Waza -a codex -g -y
 
 Install just one with `npx skills add tw93/Waza --skill think -a codex -g -y`. Codex sessions can invoke installed skills by name or link to the installed `SKILL.md` path shown by `npx skills path tw93/Waza`.
 
-**Claude Code plugin marketplace**
+**Claude Code plugin marketplace** (requires Claude Code v2.1.143+)
 
 ```bash
 /plugin marketplace add tw93/Waza
-/plugin install waza@waza
+/plugin install waza@waza          # full bundle, registers all eight /waza:* skills
+/plugin install waza-think@waza    # or install a single per-skill entry
 ```
-
-Use the bundle for now. Per-skill marketplace entries like `waza-think@waza` are temporarily affected by a Claude Code v2.1.136+ path-validation regression; until upstream fixes it, install one skill with the `npx skills add ... --skill` path above.
 
 **Claude Desktop**
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Install just one with `npx skills add tw93/Waza --skill think -a codex -g -y`. C
 
 ```bash
 /plugin marketplace add tw93/Waza
-/plugin install waza@waza          # full bundle, registers all eight /waza:* skills
-/plugin install waza-think@waza    # or install a single per-skill entry
+/plugin install waza@waza
 ```
+
+This installs all eight skills. Install just one with `/plugin install waza-<name>@waza` (e.g. `waza-think@waza`).
 
 **Claude Desktop**
 


### PR DESCRIPTION
## 背景

[`anthropics/claude-code#57570`](https://github.com/anthropics/claude-code/issues/57570) 在 v2.1.136-v2.1.141 期间把 `"skills": ["./"]` 误判为 `path escapes plugin directory`，上游已在 [**v2.1.142**](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21142) 修复。[**v2.1.143**](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21143) 又加了一条自动识别：plugin source 根目录有 `SKILL.md`、没有 `skills/` 子目录时，Claude Code 直接把它注册成 skill。

Waza 的 8 个 per-skill 条目(`source: "./skills/<name>"`)对应这个条件：每个 source 目录只有一份 `SKILL.md`，无嵌套 `skills/` 子目录。这 8 个条目里的 `"skills": ["./"]` 和 `"strict": false` 不再需要。bundle 条目(`source: "./"`)走默认的 `skills/<name>/SKILL.md` 自动发现路径，加载行为不变。

本仓库 #48 当时记录了这次 regression 对 Waza per-skill 入口的影响，上游修复后已关闭。

## 改动

- `.claude-plugin/marketplace.json`：
  - 删 8 个 per-skill 条目(`waza-{think,check,hunt,design,read,write,learn,health}`)里的 `"skills": ["./"]` 和 `"strict": false`。
  - bundle 条目 description 里那句"per-skill marketplace 入口受上游影响"换成 `use /plugin install waza-<name>@waza instead`。
- `README.md`：
  - Claude Code plugin marketplace 子章节标题标注 v2.1.143+ 最低版本。
  - 命令块下面加一句话说明 bundle 和 per-skill 两种入口。
  - 删掉原来解释 v2.1.136+ regression 的段落。

`npx skills add tw93/Waza -a claude-code -g -y` 这条路径不动，Claude Code v2.1.143 之前的用户继续走它。

## 验证

实测 Claude Code **v2.1.143**：

- **本地路径**：`/plugin marketplace add <local-checkout>` + `/plugin install waza@waza`(bundle)+ 两个 per-skill 条目(`waza-think`、`waza-check`)→ `/doctor` 无 error，`/waza:think`、`/waza:check`、`/waza-think:think`、`/waza-check:check` 激活。
- **远程路径**：`/plugin marketplace add qishaoyumu/Waza@refactor/claude-code-marketplace` + bundle + 两个 per-skill 条目(`waza-think`、`waza-check`)→ `/doctor` 无 error，8 个 `/waza:*`、`/waza-think:think`、`/waza-check:check` 激活。
- **Lint**：`make verify-docs` 全部检查通过(marketplace.json 字段一致性、SKILL.md frontmatter、markdown links、table pipes 等)。
