### PR TITLE
fix(statusline): gate lower live quota snapshots

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -10,6 +10,7 @@ HIGHWATER_LOCK_DIR="$CACHE_DIR/highwater.lock"
 CACHE_MAX_AGE=21600  # 6 hours: one full rate_limit window
 HIGHWATER_LOCK_MAX_AGE=10
 HIGHWATER_RESET_SKEW_MAX=7200  # tolerate session jitter, reject crossed windows
+HIGHWATER_DROP_RESET_MIN=5  # fresh lower live values must drop by at least 5%
 
 input=$(cat)
 
@@ -20,6 +21,9 @@ jq_full='[
    + (.context_window.current_usage.cache_creation_input_tokens // 0)
    + (.context_window.current_usage.cache_read_input_tokens // 0) | tostring),
   (.context_window.context_window_size // 0 | tostring),
+  (.session_id // "null" | tostring),
+  (.cost.total_api_duration_ms // 0 | tonumber? // 0 | floor | tostring),
+  (.context_window.total_output_tokens // 0 | tonumber? // 0 | floor | tostring),
   (.rate_limits.five_hour.used_percentage // null | if . then (. | round | tostring) else "null" end),
   (.rate_limits.five_hour.resets_at // "" | tostring),
   (.rate_limits.seven_day.used_percentage // null | if . then (. | round | tostring) else "null" end),
@@ -31,6 +35,16 @@ jq_rl='[
   (.rate_limits.five_hour.resets_at // "" | tostring),
   (.rate_limits.seven_day.used_percentage // null | if . then (. | round | tostring) else "null" end),
   (.rate_limits.seven_day.resets_at // "" | tostring)
+] | @tsv'
+
+jq_hw='[
+  (.five_hour.used_percentage // null | if . then (. | round | tostring) else "null" end),
+  (.five_hour.resets_at // "null" | tostring),
+  (.seven_day.used_percentage // null | if . then (. | round | tostring) else "null" end),
+  (.seven_day.resets_at // "null" | tostring),
+  (._last.session_id // "null" | tostring),
+  (._last.api_duration_ms // 0 | tonumber? // 0 | floor | tostring),
+  (._last.output_tokens // 0 | tonumber? // 0 | floor | tostring)
 ] | @tsv'
 
 cache_file_mtime() {
@@ -79,11 +93,40 @@ read_highwater() {
   hw_5h_reset=""
   hw_7d_pct=""
   hw_7d_reset=""
+  hw_last_session_id=""
+  hw_last_api_ms="0"
+  hw_last_output_tokens="0"
   [ -f "$HIGHWATER_FILE" ] || return
-  hw_5h_pct=$(jq -r 'if .five_hour.used_percentage == null then "" else (.five_hour.used_percentage | round | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
-  hw_5h_reset=$(jq -r 'if .five_hour.resets_at == null then "" else (.five_hour.resets_at | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
-  hw_7d_pct=$(jq -r 'if .seven_day.used_percentage == null then "" else (.seven_day.used_percentage | round | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
-  hw_7d_reset=$(jq -r 'if .seven_day.resets_at == null then "" else (.seven_day.resets_at | tostring) end' "$HIGHWATER_FILE" 2>/dev/null)
+  highwater_data=$(jq -r "$jq_hw" "$HIGHWATER_FILE" 2>/dev/null)
+  IFS="$tab" read -r hw_5h_pct hw_5h_reset hw_7d_pct hw_7d_reset hw_last_session_id hw_last_api_ms hw_last_output_tokens <<EOF
+$highwater_data
+EOF
+  [ "$hw_5h_pct" = "null" ] && hw_5h_pct=""
+  [ "$hw_5h_reset" = "null" ] && hw_5h_reset=""
+  [ "$hw_7d_pct" = "null" ] && hw_7d_pct=""
+  [ "$hw_7d_reset" = "null" ] && hw_7d_reset=""
+  [ "$hw_last_session_id" = "null" ] && hw_last_session_id=""
+  is_uint "$hw_last_api_ms" || hw_last_api_ms=0
+  is_uint "$hw_last_output_tokens" || hw_last_output_tokens=0
+}
+
+json_quote() {
+  printf '%s' "$1" | jq -Rs . 2>/dev/null
+}
+
+compute_fresh_activity() {
+  fresh_activity=0
+  [ "$live_rate_limits_present" = "1" ] || return
+  [ -n "$live_session_id" ] && [ "$live_session_id" != "null" ] || return
+  [ "$live_session_id" = "$hw_last_session_id" ] || return
+  is_uint "$live_api_ms" || live_api_ms=0
+  is_uint "$live_output_tokens" || live_output_tokens=0
+  is_uint "$hw_last_api_ms" || hw_last_api_ms=0
+  is_uint "$hw_last_output_tokens" || hw_last_output_tokens=0
+  if [ "$live_api_ms" -gt "$hw_last_api_ms" ] 2>/dev/null \
+    || [ "$live_output_tokens" -gt "$hw_last_output_tokens" ] 2>/dev/null; then
+    fresh_activity=1
+  fi
 }
 
 # apply_hw: compares live vs high-water marks for a single counter (5h or 7d).
@@ -132,28 +175,62 @@ apply_hw() {
     applied_hw_reset="$hw_reset"
     return
   fi
-  applied_pct="$live_pct"
-  applied_reset="$live_reset"
-  applied_hw_pct="$live_pct"
-  applied_hw_reset="$live_reset"
+  if [ "$hw_ok" = "0" ] || [ "$live_pct" -gt "$hw_pct" ] 2>/dev/null; then
+    applied_pct="$live_pct"
+    applied_reset="$live_reset"
+    applied_hw_pct="$live_pct"
+    applied_hw_reset="$live_reset"
+    return
+  fi
+  if [ "$fresh_activity" = "1" ] \
+    && is_uint "$live_reset" && is_uint "$hw_reset" \
+    && [ "$live_pct" -lt "$hw_pct" ] 2>/dev/null \
+    && [ $((hw_pct - live_pct)) -ge "$HIGHWATER_DROP_RESET_MIN" ] 2>/dev/null; then
+    applied_pct="$live_pct"
+    applied_reset="$live_reset"
+    applied_hw_pct="$live_pct"
+    applied_hw_reset="$live_reset"
+    return
+  fi
+
+  applied_pct="$hw_pct"
+  applied_reset="${live_reset:-$hw_reset}"
+  applied_hw_pct="$hw_pct"
+  applied_hw_reset="$hw_reset"
 }
 
 write_highwater() {
   is_uint "$new_hw_5h_pct" || is_uint "$new_hw_7d_pct" || return
   mkdir -p "$CACHE_DIR" 2>/dev/null || return
   local r5="${new_hw_5h_reset:-0}" r7="${new_hw_7d_reset:-0}"
+  local wrote=0 sid_json
   is_uint "$r5" || r5=0
   is_uint "$r7" || r7=0
   if ! {
     {
       printf '{\n'
+      if [ "$live_rate_limits_present" = "1" ] \
+        && [ -n "$live_session_id" ] && [ "$live_session_id" != "null" ]; then
+        sid_json=$(json_quote "$live_session_id")
+        printf '  "_last": {"session_id": %s, "api_duration_ms": %s, "output_tokens": %s}' \
+          "${sid_json:-\"\"}" "${live_api_ms:-0}" "${live_output_tokens:-0}"
+        wrote=1
+      elif [ -n "$hw_last_session_id" ]; then
+        sid_json=$(json_quote "$hw_last_session_id")
+        printf '  "_last": {"session_id": %s, "api_duration_ms": %s, "output_tokens": %s}' \
+          "${sid_json:-\"\"}" "${hw_last_api_ms:-0}" "${hw_last_output_tokens:-0}"
+        wrote=1
+      fi
       if is_uint "$new_hw_5h_pct"; then
+        [ "$wrote" = "1" ] && printf ',\n'
         printf '  "five_hour": {"used_percentage": %s, "resets_at": %s}' "$new_hw_5h_pct" "$r5"
-        is_uint "$new_hw_7d_pct" && printf ','
-        printf '\n'
+        wrote=1
       fi
       if is_uint "$new_hw_7d_pct"; then
+        [ "$wrote" = "1" ] && printf ',\n'
         printf '  "seven_day": {"used_percentage": %s, "resets_at": %s}\n' "$new_hw_7d_pct" "$r7"
+      else
+        printf '\n'
       fi
       printf '}\n'
     } > "${HIGHWATER_FILE}.tmp" 2>/dev/null \
@@ -165,6 +242,7 @@ write_highwater() {
 
 apply_highwater_all() {
   read_highwater
+  compute_fresh_activity
 
   apply_hw "$five_pct" "$five_reset" "$hw_5h_pct" "$hw_5h_reset"
   five_pct="$applied_pct"
@@ -183,14 +261,23 @@ apply_highwater_all() {
 parsed=""
 [ -n "$input" ] && parsed=$(printf '%s' "$input" | jq -r "$jq_full" 2>/dev/null)
 
-IFS="$tab" read -r used_tokens window_size live_five_pct live_five_reset live_seven_pct live_seven_reset <<EOF
+IFS="$tab" read -r used_tokens window_size live_session_id live_api_ms live_output_tokens live_five_pct live_five_reset live_seven_pct live_seven_reset <<EOF
 $parsed
 EOF
 
+live_session_id="${live_session_id:-}"
+[ "$live_session_id" = "null" ] && live_session_id=""
+live_api_ms="${live_api_ms:-0}"
+live_output_tokens="${live_output_tokens:-0}"
 five_pct="${live_five_pct:-}"
 five_reset="${live_five_reset:-}"
 seven_pct="${live_seven_pct:-}"
 seven_reset="${live_seven_reset:-}"
+live_rate_limits_present=0
+if { [ "$five_pct" != "null" ] && [ -n "$five_pct" ]; } \
+  || { [ "$seven_pct" != "null" ] && [ -n "$seven_pct" ]; }; then
+  live_rate_limits_present=1
+fi
 
 # If rate_limits missing from live input, read from cache
 if [ "$five_pct" = "null" ] || [ -z "$five_pct" ]; then

--- a/tests/test_statusline.sh
+++ b/tests/test_statusline.sh
@@ -20,16 +20,58 @@ grep -q '5h:' "$tmpdir/out2"
 grep -q '7d:' "$tmpdir/out2"
 grep -q '12%' "$tmpdir/out2"
 grep -q '34%' "$tmpdir/out3"
-grep -q '1%' "$tmpdir/out4"
 grep -q '61%' "$tmpdir/out4"
+grep -q '63%' "$tmpdir/out4"
 
-# Live values override existing high-water mark.
+# Existing high-water mark survives a fresh session with lower live values.
 tmpdir2=$(make_tmpdir)
 mkdir -p "$tmpdir2/.cache/waza-statusline"
 printf '%s\n' '{"seven_day":{"used_percentage":63,"resets_at":2000003600}}' > "$tmpdir2/.cache/waza-statusline/highwater.json"
 printf '%s' "$json1" | HOME="$tmpdir2" bash "$ROOT/scripts/statusline.sh" >"$tmpdir2/out"
 grep -q '12%' "$tmpdir2/out"
-grep -q '34%' "$tmpdir2/out"
+grep -q '63%' "$tmpdir2/out"
+
+# A lower live value may reset high-water only after a fresh API activity in
+# the same session. This catches Claude-side quota corrections where resets_at
+# stays unchanged but the used percentage drops.
+tmpdir2a=$(make_tmpdir)
+mkdir -p "$tmpdir2a/.cache/waza-statusline"
+printf '%s\n' '{"_last":{"session_id":"s1","api_duration_ms":100,"output_tokens":1000},"seven_day":{"used_percentage":80,"resets_at":2000003600}}' \
+  > "$tmpdir2a/.cache/waza-statusline/highwater.json"
+json_fresh_drop='{"session_id":"s1","cost":{"total_api_duration_ms":110},"context_window":{"total_output_tokens":1010,"current_usage":{"input_tokens":10},"context_window_size":100},"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":2000000000},"seven_day":{"used_percentage":14,"resets_at":2000003600}}}'
+printf '%s' "$json_fresh_drop" | HOME="$tmpdir2a" bash "$ROOT/scripts/statusline.sh" >"$tmpdir2a/out"
+grep -q '14%' "$tmpdir2a/out"
+jq -e '.seven_day.used_percentage == 14 and ._last.session_id == "s1" and ._last.api_duration_ms == 110' \
+  "$tmpdir2a/.cache/waza-statusline/highwater.json" >/dev/null
+
+# A tick without live rate_limits may use cached quota, but must not advance the
+# freshness marker. The next live quota response still needs to count as fresh.
+tmpdir2aa=$(make_tmpdir)
+mkdir -p "$tmpdir2aa/.cache/waza-statusline"
+printf '%s\n' '{"_last":{"session_id":"s1","api_duration_ms":100,"output_tokens":1000},"seven_day":{"used_percentage":80,"resets_at":2000003600}}' \
+  > "$tmpdir2aa/.cache/waza-statusline/highwater.json"
+printf '%s\n' '{"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":2000000000},"seven_day":{"used_percentage":80,"resets_at":2000003600}}}' \
+  > "$tmpdir2aa/.cache/waza-statusline/last.json"
+json_no_live_rate_limits='{"session_id":"s1","cost":{"total_api_duration_ms":110},"context_window":{"total_output_tokens":1010,"current_usage":{"input_tokens":10},"context_window_size":100}}'
+printf '%s' "$json_no_live_rate_limits" | HOME="$tmpdir2aa" bash "$ROOT/scripts/statusline.sh" >"$tmpdir2aa/out1"
+grep -q '80%' "$tmpdir2aa/out1"
+jq -e '._last.api_duration_ms == 100 and ._last.output_tokens == 1000' \
+  "$tmpdir2aa/.cache/waza-statusline/highwater.json" >/dev/null
+printf '%s' "$json_fresh_drop" | HOME="$tmpdir2aa" bash "$ROOT/scripts/statusline.sh" >"$tmpdir2aa/out2"
+grep -q '14%' "$tmpdir2aa/out2"
+jq -e '.seven_day.used_percentage == 14 and ._last.api_duration_ms == 110' \
+  "$tmpdir2aa/.cache/waza-statusline/highwater.json" >/dev/null
+
+# Small fresh dips are treated as jitter, not a reset/correction.
+tmpdir2b=$(make_tmpdir)
+mkdir -p "$tmpdir2b/.cache/waza-statusline"
+printf '%s\n' '{"_last":{"session_id":"s1","api_duration_ms":100,"output_tokens":1000},"seven_day":{"used_percentage":63,"resets_at":2000003600}}' \
+  > "$tmpdir2b/.cache/waza-statusline/highwater.json"
+json_small_dip='{"session_id":"s1","cost":{"total_api_duration_ms":110},"context_window":{"total_output_tokens":1010,"current_usage":{"input_tokens":10},"context_window_size":100},"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":2000000000},"seven_day":{"used_percentage":61,"resets_at":2000003600}}}'
+printf '%s' "$json_small_dip" | HOME="$tmpdir2b" bash "$ROOT/scripts/statusline.sh" >"$tmpdir2b/out"
+grep -q '63%' "$tmpdir2b/out"
+jq -e '.seven_day.used_percentage == 63 and ._last.api_duration_ms == 110' \
+  "$tmpdir2b/.cache/waza-statusline/highwater.json" >/dev/null
 
 # Empty input must not crash; both rate-limit slots fall back to "--".
 tmpdir3=$(make_tmpdir)


### PR DESCRIPTION
## Summary

- keep live quota increases and fresh quota resets working
- prevent stale lower live snapshots from overwriting high-water quota values
- preserve the freshness marker when a statusline tick lacks live rate_limits

## Context

This is a follow-up to #47, which added high-water protection for stale per-session rate-limit snapshots.

Tw93 later simplified that behavior in 366b54a ("fix: statusline shows live rate-limit values instead of high-water mark") so live values always win and high-water is only a fallback when rate_limits is missing.

That fixed reset/correction cases, but it reopens the stale-low case from #47. In testing, one Claude Code session kept reporting 5h at 1% while another session had already observed 5%; the live-priority script displayed 1% and persisted that lower value into highwater.json.

This patch keeps high-water protection for lower live values unless the lower value is tied to fresh activity in the same session. That preserves reset behavior while avoiding stale cross-session dips.

## Real-world testing

I have been running this variant locally for roughly one to two weeks. During that period it handled the stale-low case correctly, and it also continued to work after an unexpected quota reset event: the displayed quota reset normally instead of getting stuck at the previous high-water value.

## Validation

- bash tests/test_statusline.sh
- make verify-scripts