### PR TITLE
fix: lead bug workflows with root cause

### DIFF
--- a/plugins/waza/skills/hunt/SKILL.md
+++ b/plugins/waza/skills/hunt/SKILL.md
@@ -20,6 +20,8 @@ A patch applied to a symptom creates a new bug somewhere else.
 - Evidence: source trace, repro command or UI path, logs or state, targeted test/build output, and runtime evidence for UI or native defects.
 - Output: root cause, fix or handoff, verification result, and any unswept sibling risks.
 
+When answering the user after a diagnostic pass, lead with the cause. The first substantive sentence must say what broke, where, and why the evidence supports it. Put the fix after the cause. Never lead a bug answer with "brute force fix", "recommended fix", implementation steps, or a plan template while the root cause is still implicit.
+
 **Do not touch code until you can state the root cause in one sentence:**
 > "I believe the root cause is [X] because [evidence]."
 
@@ -51,6 +53,7 @@ For `/hunt`, diagnostic constraints are `decision`, `preference`, and `principle
 - **Behavioral / lifecycle / async bugs: instrument first, not after failure.** Window lifecycle, event delivery, navigation, focus, timer, state-machine, and async-ordering bugs almost never yield to static reading alone. Do not wait for a failed fix to add logs. The moment your hypothesis involves "this callback fires before/after that one", "this state should be X when Y runs", or "this object should still be alive here", **add the log immediately as part of forming the hypothesis**, before writing any fix. A hypothesis without runtime evidence is a guess; two guesses in a row is the hard-stop signal. Distinguish from visual-rendering bugs (compositor behavior needs DevTools, not logs) and pure-logic bugs (wrong formula, off-by-one) where static analysis is sufficient.
 - **Tuning magic numbers past round three: stop, unify.** When a spacing / sizing / threshold value has been adjusted three times and still looks wrong, the bug is structural, not numeric. Replace the N independent values with one named token (`Spacing.s4`, `--gap-content`, etc.) and verify the asymmetry was hiding a missing constraint. Asymmetry that survives tuning is structural; more tuning will not converge.
 - **Fix the cause, not the symptom.** If the fix touches more than 5 files, pause and confirm scope with the user.
+- **Root cause owns the output order.** If another skill, review format, or planning mode is also active, keep the bug section in root-cause-first order: cause -> evidence -> symptom chain -> fix -> verification. The other skill can shape the handoff, but it must not move the fix before the cause.
 
 ## Fix Scope Discipline
 

--- a/plugins/waza/skills/think/SKILL.md
+++ b/plugins/waza/skills/think/SKILL.md
@@ -34,6 +34,8 @@ Before outputting any plan, scan the project's `AGENTS.md`, `CLAUDE.md`, `.claud
 
 Activate when the user wants to fix something rather than build something, the problem is already defined, and the only open question is "how to fix it."
 
+Do not use Lightweight Mode as the leading structure for bugs, regressions, crashes, failing tests, or "why is this broken?" requests. If a bug diagnosis is involved, `/hunt` owns the output order: root cause first, then evidence, then symptom chain, then fix. Only append a lightweight implementation plan after the root cause is explicit and supported.
+
 Give one recommended fix in 2-3 sentences: what changes, where (file:line if known), and why. Name the brute-force version in one line first; default to it unless the user wants elegance. List involved files, flag explicitly if more than 5. State one risk. Wait for approval before implementing.
 
 Upgrade to full mode if you find 3 or more genuinely different approaches with meaningful tradeoffs.
@@ -158,6 +160,7 @@ When the user later says "Implement the plan", "可以干", "直接改", "整", 
 | Planned MCP workflow without checking if MCP was loaded | Verify tool availability before handing off, not mid-implementation |
 | Rejected design restarted from scratch | Ask what specifically failed, re-enter with narrowed constraints |
 | User said "just fix X" and skipped /think | If the fix touches 3+ files or needs a method choice, pause and run Lightweight Mode |
+| User used `/think` around a bug or `/hunt` task | Keep `/hunt` root-cause-first ordering. Do not start with "brute force fix" or an implementation plan until the bug cause and evidence are stated. |
 | User approved a concrete plan and the agent debated the plan again | Execute the approved plan. Only stop for repo drift, missing permissions, or unsafe external state |
 | Picked a regional or locale-specific API variant without checking | List all regional or locale differences before writing integration code |
 | Introduced a second language or runtime into a single-stack project | Never add a new language or runtime without explicit approval |

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -20,6 +20,8 @@ A patch applied to a symptom creates a new bug somewhere else.
 - Evidence: source trace, repro command or UI path, logs or state, targeted test/build output, and runtime evidence for UI or native defects.
 - Output: root cause, fix or handoff, verification result, and any unswept sibling risks.
 
+When answering the user after a diagnostic pass, lead with the cause. The first substantive sentence must say what broke, where, and why the evidence supports it. Put the fix after the cause. Never lead a bug answer with "brute force fix", "recommended fix", implementation steps, or a plan template while the root cause is still implicit.
+
 **Do not touch code until you can state the root cause in one sentence:**
 > "I believe the root cause is [X] because [evidence]."
 
@@ -51,6 +53,7 @@ For `/hunt`, diagnostic constraints are `decision`, `preference`, and `principle
 - **Behavioral / lifecycle / async bugs: instrument first, not after failure.** Window lifecycle, event delivery, navigation, focus, timer, state-machine, and async-ordering bugs almost never yield to static reading alone. Do not wait for a failed fix to add logs. The moment your hypothesis involves "this callback fires before/after that one", "this state should be X when Y runs", or "this object should still be alive here", **add the log immediately as part of forming the hypothesis**, before writing any fix. A hypothesis without runtime evidence is a guess; two guesses in a row is the hard-stop signal. Distinguish from visual-rendering bugs (compositor behavior needs DevTools, not logs) and pure-logic bugs (wrong formula, off-by-one) where static analysis is sufficient.
 - **Tuning magic numbers past round three: stop, unify.** When a spacing / sizing / threshold value has been adjusted three times and still looks wrong, the bug is structural, not numeric. Replace the N independent values with one named token (`Spacing.s4`, `--gap-content`, etc.) and verify the asymmetry was hiding a missing constraint. Asymmetry that survives tuning is structural; more tuning will not converge.
 - **Fix the cause, not the symptom.** If the fix touches more than 5 files, pause and confirm scope with the user.
+- **Root cause owns the output order.** If another skill, review format, or planning mode is also active, keep the bug section in root-cause-first order: cause -> evidence -> symptom chain -> fix -> verification. The other skill can shape the handoff, but it must not move the fix before the cause.
 
 ## Fix Scope Discipline
 

--- a/skills/think/SKILL.md
+++ b/skills/think/SKILL.md
@@ -34,6 +34,8 @@ Before outputting any plan, scan the project's `AGENTS.md`, `CLAUDE.md`, `.claud
 
 Activate when the user wants to fix something rather than build something, the problem is already defined, and the only open question is "how to fix it."
 
+Do not use Lightweight Mode as the leading structure for bugs, regressions, crashes, failing tests, or "why is this broken?" requests. If a bug diagnosis is involved, `/hunt` owns the output order: root cause first, then evidence, then symptom chain, then fix. Only append a lightweight implementation plan after the root cause is explicit and supported.
+
 Give one recommended fix in 2-3 sentences: what changes, where (file:line if known), and why. Name the brute-force version in one line first; default to it unless the user wants elegance. List involved files, flag explicitly if more than 5. State one risk. Wait for approval before implementing.
 
 Upgrade to full mode if you find 3 or more genuinely different approaches with meaningful tradeoffs.
@@ -158,6 +160,7 @@ When the user later says "Implement the plan", "可以干", "直接改", "整", 
 | Planned MCP workflow without checking if MCP was loaded | Verify tool availability before handing off, not mid-implementation |
 | Rejected design restarted from scratch | Ask what specifically failed, re-enter with narrowed constraints |
 | User said "just fix X" and skipped /think | If the fix touches 3+ files or needs a method choice, pause and run Lightweight Mode |
+| User used `/think` around a bug or `/hunt` task | Keep `/hunt` root-cause-first ordering. Do not start with "brute force fix" or an implementation plan until the bug cause and evidence are stated. |
 | User approved a concrete plan and the agent debated the plan again | Execute the approved plan. Only stop for repo drift, missing permissions, or unsafe external state |
 | Picked a regional or locale-specific API variant without checking | List all regional or locale differences before writing integration code |
 | Introduced a second language or runtime into a single-stack project | Never add a new language or runtime without explicit approval |


### PR DESCRIPTION
## Summary
- Make `/hunt` user-facing diagnostic answers lead with the root cause before fix advice.
- Make `/think` defer bug/failure output ordering to `/hunt` before appending implementation plans.
- Regenerate the Codex plugin mirror for the changed skill bodies.

## Validation
- `python3 scripts/verify_skills.py`
- `make regenerate`
- `make test` (stopped at `smoke-package` because local `zip` is not installed)
- `make smoke-punctuation smoke-read-fetch smoke-routing-installer smoke-skills-add-e2e smoke-statusline-installer smoke-statusline smoke-validators smoke-verifier-output smoke-verify-skills`