### PR TITLE
feat: add Google Antigravity CLI plugin support and rules installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Each skill is a folder with reference docs, helper scripts, and gotchas from rea
 One command installs all eight skills, with no prompts and no errors. Copy and run:
 
 ```bash
-npx skills add tw93/Waza -a claude-code codex cursor -g -y
+npx skills add tw93/Waza -a claude-code codex cursor antigravity-cli -g -y
 ```
 
-One canonical copy lands in the shared `~/.agents/skills` store (the agents.md standard directory) with Claude Code symlinked in, so Codex, Cursor, Kimi Code CLI, Amp, Cline, and every other agent reading that directory picks Waza up automatically. Models routed through these harnesses (GLM or Kimi K2 behind Claude Code-compatible endpoints) need nothing extra; tools with a private skills directory append their agent id (e.g. `-a qwen-code iflow-cli`). Update later with `npx skills update -g -y`.
+One canonical copy lands in the shared `~/.agents/skills` store (the agents.md standard directory) with Claude Code symlinked in, so Codex, Cursor, Kimi Code CLI, Amp, Cline, Antigravity CLI, and every other agent reading that directory picks Waza up automatically. Models routed through these harnesses (GLM or Kimi K2 behind Claude Code-compatible endpoints) need nothing extra; tools with a private skills directory append their agent id (e.g. `-a qwen-code iflow-cli antigravity-cli`). Update later with `npx skills update -g -y`.
 
 **Native plugin** (for host-native update commands)
 
@@ -99,7 +99,7 @@ Codex shows remaining quota; the Claude Code statusline above shows used percent
 
 ### Optional Rules
 
-Three independent toggles. Copy the ones you want (swap `claude-code` for `codex` on Codex):
+Three independent toggles. Copy the ones you want (swap `claude-code` for `codex` or `antigravity-cli` on those agents):
 
 ```bash
 # English coaching: appends a short 😇 correction when your prompt has an English mistake

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "claude-code",
     "codex",
     "antigravity",
-    "opencode"
+    "opencode",
+    "antigravity-cli"
   ],
   "files": [
     "LICENSE",

--- a/plugins/waza/plugin.json
+++ b/plugins/waza/plugin.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "waza",
+  "description": "Engineering workflow skills for Antigravity CLI: think, check, hunt, ui, read, write, learn, and health."
+}

--- a/scripts/build_metadata.py
+++ b/scripts/build_metadata.py
@@ -207,6 +207,14 @@ def build_codex_plugin(version: str) -> dict:
     }
 
 
+def build_agy_plugin() -> dict:
+    return {
+        "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+        "name": "waza",
+        "description": CODEX_DESCRIPTION.replace("Codex", "Antigravity CLI"),
+    }
+
+
 def build_codex_marketplace() -> dict:
     return {
         "name": "waza",
@@ -252,6 +260,7 @@ def build_package_json(version: str) -> str:
             "codex",
             "antigravity",
             "opencode",
+            "antigravity-cli"
         ],
         "files": [
             "LICENSE",
@@ -403,17 +412,19 @@ def shared_asset_source(rel: str) -> str:
 
 def collect_codex_plugin_tree(
     root: Path,
-    plugin_manifest_rendered: str,
+    codex_plugin_rendered: str,
+    agy_plugin_rendered: str,
     generated_skill_files: dict[str, bytes],
 ) -> dict[str, bytes]:
-    """Build the generated file set for the Codex plugin directory.
+    """Build the generated file set for the Codex and Antigravity plugin directory.
 
     Codex installs only the directory referenced by marketplace source.path, so
     the plugin tree contains real copies of the skill and rule files instead of
     symlinks or references back to the repository root.
     """
     generated = {
-        "plugins/waza/.codex-plugin/plugin.json": plugin_manifest_rendered.encode()
+        "plugins/waza/.codex-plugin/plugin.json": codex_plugin_rendered.encode(),
+        "plugins/waza/plugin.json": agy_plugin_rendered.encode(),
     }
     for source_name in ("skills", "rules"):
         source_root = root / source_name
@@ -453,6 +464,7 @@ def main() -> int:
     marketplace = build_marketplace(version, skills)
     rendered = render_json(marketplace)
     codex_plugin_rendered = render_json(build_codex_plugin(version))
+    agy_plugin_rendered = render_json(build_agy_plugin())
     codex_marketplace_rendered = render_json(build_codex_marketplace())
     package_rendered = build_package_json(version)
 
@@ -499,6 +511,7 @@ def main() -> int:
     codex_plugin_tree = collect_codex_plugin_tree(
         root,
         codex_plugin_rendered,
+        agy_plugin_rendered,
         skill_shared_assets,
     )
 

--- a/scripts/checks_distribution.py
+++ b/scripts/checks_distribution.py
@@ -352,7 +352,7 @@ def check_readme_install_command(root: Path):
     # that lack global-install support and prints a "Failed to install" block.
     # Naming agents installs cleanly; codex and cursor share `~/.agents/skills`,
     # so other universal agents pick the skills up without being listed.
-    expected = "npx skills add tw93/Waza -a claude-code codex cursor -g -y"
+    expected = "npx skills add tw93/Waza -a claude-code codex cursor antigravity-cli -g -y"
     if expected not in text:
         fail(
             f"README INSTALL COMMAND: README.md must include {expected!r}\n"

--- a/scripts/setup-rule.sh
+++ b/scripts/setup-rule.sh
@@ -3,7 +3,7 @@
 # (~/.codex/AGENTS.md, wrapped in markers so re-runs replace the block).
 #
 # Usage:
-#   setup-rule.sh <rule-name> [claude-code|codex]
+#   setup-rule.sh <rule-name> [claude-code|codex|antigravity-cli]
 #
 # rule-name corresponds to a file at rules/<rule-name>.md in this repo. Marker
 # label is derived from the rule slug (e.g. anti-patterns -> Anti-Patterns,
@@ -16,7 +16,7 @@ TARGET="${2:-claude-code}"
 WAZA_REF="${WAZA_REF:-v3.31.2}"
 
 if [ -z "$RULE" ]; then
-  echo "Usage: setup-rule.sh <rule-name> [claude-code|codex]" >&2
+  echo "Usage: setup-rule.sh <rule-name> [claude-code|codex|antigravity-cli]" >&2
   echo "Examples: setup-rule.sh anti-patterns" >&2
   echo "          setup-rule.sh english codex" >&2
   exit 1
@@ -104,8 +104,14 @@ PYEOF
     echo "Waza ${MARKER_LABEL} installed for Codex."
     ;;
 
+  antigravity-cli|antigravity|agy)
+    mkdir -p "$HOME/.gemini/antigravity-cli/rules"
+    curl -fsSL --connect-timeout 10 --max-time 60 "$RAW" -o "$HOME/.gemini/antigravity-cli/rules/${RULE}.md"
+    echo "Waza ${MARKER_LABEL} installed for Antigravity."
+    ;;
+
   *)
-    echo "Usage: setup-rule.sh <rule-name> [claude-code|codex]" >&2
+    echo "Usage: setup-rule.sh <rule-name> [claude-code|codex|antigravity-cli]" >&2
     exit 1
     ;;
 esac

--- a/tests/python/test_build_metadata.py
+++ b/tests/python/test_build_metadata.py
@@ -113,10 +113,11 @@ def test_collect_codex_plugin_tree_ignores_local_cache_files(tmp_path):
     (rules_dir / "waza-routing.md").write_text("routing\n")
     (rules_dir / ".DS_Store").write_bytes(b"noise")
 
-    tree = bm.collect_codex_plugin_tree(tmp_path, "{}\n", {})
+    tree = bm.collect_codex_plugin_tree(tmp_path, "{}\n", "{}\n", {})
 
     assert "plugins/waza/skills/check/scripts/run.py" in tree
     assert "plugins/waza/rules/waza-routing.md" in tree
+    assert "plugins/waza/plugin.json" in tree
     assert all("__pycache__" not in path for path in tree)
     assert all(not path.endswith((".pyc", ".DS_Store")) for path in tree)
 


### PR DESCRIPTION
Hi @tw93, thanks for the feedback!

I have fully reverted the Korean-specific rules/checkers as requested, and created this focused PR to add support for **Google Antigravity CLI(`agy`)**.

While the universal skills path helps, `plugin.json` and the rules path are indeed mandatory for `antigravity-cli` to recognize the package as a valid plugin and to install the custom rules properly.

Here is the concrete verification and logs from a live `antigravity-cli` environment with these changes:

### 1. Manifest Validation

Without `plugin.json` at the root of `plugins/waza`, validation fails.
With this PR, the manifest is successfully recognized:
```bash
$ agy plugin validate plugins/waza
[ok]    plugins/waza
✔ skills      : 9 processed
```

### 2. Plugin Installation

The plugin successfully installs to the default `.gemini/antigravity-cli/` app data directory and compiles the skills:
```bash
$ agy plugin install plugins/waza
[ok]    waza
```

### 3. Active Plugin Registry

The plugin is correctly registered and listed inside the CLI imports manifest:
```bash
$ agy plugin list
{
  "imports": [
      {
          "name": "waza",
          "source": "antigravity",
          "importedAt": "2026-07-17T23:33:40Z",
          "components": [
              "skills"
          ]
      }
  ]
}
```

### 4. Setup Rule Output

Additionally, `setup-rule.sh <rule-name> antigravity-cli` successfully downloads and maps the rules to `~/.gemini/antigravity-cli/rules/` which the active CLI sessions read.

### Changes Summary

- **Manifest:** Added generation of `plugins/waza/plugin.json` conforming to the `antigravity.google` plugin schema.
- **Rules Installer:** Added support for `antigravity-cli` / `antigravity` / `agy` targets in `scripts/setup-rule.sh` pointing to the correct app-data directory.
- **README & Dist:** Documented `antigravity-cli` under `npx skills add` and ensured `checks_distribution.py` remains in sync.