### PR TITLE
fix: preserve statusline on download failure

### DIFF
--- a/scripts/setup-statusline.sh
+++ b/scripts/setup-statusline.sh
@@ -41,6 +41,26 @@ fi
 
 mkdir -p "$CLAUDE_DIR"
 
+download_statusline_atomically() {
+  local temporary status
+  temporary="$(mktemp "${DEST}.tmp.XXXXXX")" || return 1
+  curl -fsSL --connect-timeout 10 --max-time 60 "$RAW" -o "$temporary" || {
+    status=$?
+    rm -f "$temporary"
+    return "$status"
+  }
+  chmod +x "$temporary" || {
+    status=$?
+    rm -f "$temporary"
+    return "$status"
+  }
+  mv -f "$temporary" "$DEST" || {
+    status=$?
+    rm -f "$temporary"
+    return "$status"
+  }
+}
+
 # Refuse to modify an invalid settings file. Overwriting it would drop unrelated keys.
 if [ -f "$SETTINGS_FILE" ]; then
   SETTINGS_FILE="$SETTINGS_FILE" python3 - <<'PYEOF'
@@ -97,9 +117,8 @@ if [ -n "$EXISTING" ]; then
   fi
 fi
 
-# Download statusline script (after any confirmation prompt)
-curl -fsSL --connect-timeout 10 --max-time 60 "$RAW" -o "$DEST"
-chmod +x "$DEST"
+# Download statusline script (after any confirmation prompt).
+download_statusline_atomically
 
 # Write statusLine into ~/.claude/settings.json
 SETTINGS_FILE="$SETTINGS_FILE" python3 - <<'PYEOF'

--- a/tests/test_statusline-installer.sh
+++ b/tests/test_statusline-installer.sh
@@ -10,8 +10,9 @@ bin_dir="$tmpdir/bin"
 mkdir -p "$home_dir/.claude" "$bin_dir"
 ln -s "$(command -v python3)" "$bin_dir/python3"
 ln -s "$(command -v jq)" "$bin_dir/jq"
-ln -s /bin/chmod "$bin_dir/chmod"
-ln -s /bin/mkdir "$bin_dir/mkdir"
+for command in chmod mkdir mktemp mv rm; do
+  ln -s "$(command -v "$command")" "$bin_dir/$command"
+done
 
 # Stub curl: writes a tiny statusline script to the -o output path.
 cat >"$bin_dir/curl" <<'CURL'
@@ -20,6 +21,10 @@ outfile=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-o" ]; then outfile="$2"; shift 2; else shift; fi
 done
+if [ "${WAZA_TEST_CURL_FAIL:-}" = "1" ]; then
+  printf "%s\n" "#!/bin/bash" "echo partial download" > "$outfile"
+  exit 22
+fi
 printf "%s\n" "#!/bin/bash" "echo statusline" > "$outfile"
 CURL
 
@@ -51,6 +56,18 @@ BREW_LOG="$tmpdir/brew.log" PATH="$bin_dir" HOME="$home_dir" /bin/bash "$ROOT/sc
 python3 -c "import json, sys; data=json.load(open(sys.argv[1])); assert data['theme'] == 'dark'; assert data['statusLine']['command'] == 'bash ~/.claude/statusline.sh'" "$home_dir/.claude/settings.json"
 test -x "$home_dir/.claude/statusline.sh"
 test ! -f "$tmpdir/brew.log"
+
+# A failed update after curl writes partial output must preserve the installed script.
+cp "$home_dir/.claude/statusline.sh" "$tmpdir/statusline.before"
+if WAZA_TEST_CURL_FAIL=1 BREW_LOG="$tmpdir/brew.log" PATH="$bin_dir" HOME="$home_dir" /bin/bash "$ROOT/scripts/setup-statusline.sh" >"$tmpdir/install-failed.out" 2>"$tmpdir/install-failed.err"; then
+  echo "setup-statusline should fail when the statusline download fails"; exit 1
+fi
+cmp "$tmpdir/statusline.before" "$home_dir/.claude/statusline.sh"
+test -x "$home_dir/.claude/statusline.sh"
+python3 -c "import json, sys; data=json.load(open(sys.argv[1])); assert data['theme'] == 'dark'; assert data['statusLine']['command'] == 'bash ~/.claude/statusline.sh'" "$home_dir/.claude/settings.json"
+if compgen -G "$home_dir/.claude/statusline.sh.tmp.*" >/dev/null; then
+  echo "failed statusline download left a temporary file"; exit 1
+fi
 
 # Foreign statusLine already present: keep it intact, no overwrite.
 printf '%s\n' '{"statusLine":{"type":"command","command":"bash ~/foreign.sh"}}' > "$home_dir/.claude/settings.json"


### PR DESCRIPTION
## What

- Download the statusline into a same-directory temporary file.
- Mark the completed download executable before atomically replacing the installed script.
- Remove the temporary file when download, permission, or replacement fails.
- Add a regression case where curl writes partial output and then exits non-zero.

## Why

`curl -o ~/.claude/statusline.sh` truncates the destination before the transfer finishes. A failed update could therefore replace a working statusline with partial content. Staging the download beside the destination keeps the existing installation intact until the new script is complete and executable.

## Testing

- Red test on unmodified `main`: the partial-download fixture changed the installed script (`cmp` failed at line 2).
- `setsid --wait bash tests/test_statusline-installer.sh` — passed.
- `make verify-scripts` — passed with ShellCheck 0.9.0.
- All repository shell smoke tests — passed.
- `make package` — passed; post-package validation passed.
- `git diff --check` — passed.
- `make test` reached 293 passed / 18 skipped; four unrelated health symlink tests fail only from this WSL `/mnt/c` checkout. The same upstream head is green in GitHub Actions.