### PR TITLE
fix(health): keep credential values out of audit output

### DIFF
--- a/plugins/waza/skills/health/SKILL.md
+++ b/plugins/waza/skills/health/SKILL.md
@@ -105,7 +105,7 @@ The collector includes both runtime-specific and agent-agnostic surfaces:
 
 ## Step 1b: MCP Live Check
 
-Test every MCP server: call one harmless tool per server. Record `live=yes/no` with error detail. Respect `enabled: false` (skip without flagging). For API keys, only check if the env var is set (`echo $VAR | head -c 5`), never print full keys.
+Test every MCP server: call one harmless tool per server. Record `live=yes/no` with error detail. Respect `enabled: false` (skip without flagging). For API keys, record only whether the environment variable is set; never emit any part of its value.
 
 ## Step 1c: Safety and security checks
 

--- a/plugins/waza/skills/health/scripts/check_maintainability.py
+++ b/plugins/waza/skills/health/scripts/check_maintainability.py
@@ -106,10 +106,14 @@ SECRET_TOKEN_RE = re.compile(
     r"[A-Za-z0-9_-]{10,})\b"
 )
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)"
-    r"(?P<separator>\s*[:=]\s*)(?:Bearer\s+|Basic\s+)?"
-    r"(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|'[^'\r\n]*(?:'|(?=\r?\n|\Z))|"
-    r"[^\s,;]+)",
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*"
+    r"(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|"
+    r"authorization|password|passwd|pwd|token|secret)(?P=quote))"
+    r"(?![A-Za-z0-9_-])"
+    r"(?P<separator>\s*[:=]\s*)"
+    r"(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|"
+    r"\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)",
     re.IGNORECASE,
 )
 PRIVATE_PATH_RE = re.compile(

--- a/plugins/waza/skills/health/scripts/collect-data.sh
+++ b/plugins/waza/skills/health/scripts/collect-data.sh
@@ -156,7 +156,7 @@ truncated = len(raw) > limit
 text = raw[:limit].decode("utf-8", errors="replace")
 text = re.sub(r"-----BEGIN [^-\r\n]+-----.*?(?:-----END [^-\r\n]+-----|\Z)", "[REDACTED PRIVATE KEY]", text, flags=re.I | re.S)
 text = re.sub(r"\b(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b", "[REDACTED]", text)
-text = re.sub(r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)(?P<separator>\s*[:=]\s*)(?:Bearer\s+|Basic\s+)?(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|\x27[^\x27\r\n]*(?:\x27|(?=\r?\n|\Z))|[^\s,;]+)", lambda m: m.group("name") + m.group("separator") + "[REDACTED]", text, flags=re.I)
+text = re.sub(r"(?<![A-Za-z0-9_-])(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|authorization|password|passwd|pwd|token|secret)(?P=quote))(?![A-Za-z0-9_-])(?P<separator>\s*[:=]\s*)(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)", lambda m: m.group("name") + m.group("separator") + "[REDACTED]", text, flags=re.I)
 text = re.sub(r"(?<![A-Za-z0-9_])(?:~[/\\]|/(?:Users|home|private|tmp|var|etc|opt|Volumes)/)[^\s`\"\x27<>]+", "[PATH]", text)
 text = re.sub(r"(?<![A-Za-z0-9_])(?:[A-Za-z]:\\|\\\\)[^\s`\"\x27<>]+", "[PATH]", text)
 text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "", text)

--- a/plugins/waza/skills/health/scripts/conversation_audit.py
+++ b/plugins/waza/skills/health/scripts/conversation_audit.py
@@ -129,9 +129,14 @@ SECRET_RE = re.compile(
     r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b"
 )
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)"
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*"
+    r"(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|"
+    r"authorization|password|passwd|pwd|token|secret)(?P=quote))"
+    r"(?![A-Za-z0-9_-])"
     r"(?P<separator>\s*[:=]\s*)"
-    r"(?:Bearer\s+|Basic\s+)?(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|'[^'\r\n]*(?:'|(?=\r?\n|\Z))|[^\s,;]+)",
+    r"(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|"
+    r"\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)",
     re.IGNORECASE,
 )
 PRIVATE_KEY_RE = re.compile(

--- a/plugins/waza/skills/health/scripts/scan_skill_security.py
+++ b/plugins/waza/skills/health/scripts/scan_skill_security.py
@@ -69,9 +69,14 @@ SECRET_RE = re.compile(
     r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b"
 )
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)"
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*"
+    r"(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|"
+    r"authorization|password|passwd|pwd|token|secret)(?P=quote))"
+    r"(?![A-Za-z0-9_-])"
     r"(?P<separator>\s*[:=]\s*)"
-    r"(?:Bearer\s+|Basic\s+)?(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|'[^'\r\n]*(?:'|(?=\r?\n|\Z))|[^\s,;]+)",
+    r"(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|"
+    r"\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)",
     re.IGNORECASE,
 )
 ABS_PATH_RE = re.compile(

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -105,7 +105,7 @@ The collector includes both runtime-specific and agent-agnostic surfaces:
 
 ## Step 1b: MCP Live Check
 
-Test every MCP server: call one harmless tool per server. Record `live=yes/no` with error detail. Respect `enabled: false` (skip without flagging). For API keys, only check if the env var is set (`echo $VAR | head -c 5`), never print full keys.
+Test every MCP server: call one harmless tool per server. Record `live=yes/no` with error detail. Respect `enabled: false` (skip without flagging). For API keys, record only whether the environment variable is set; never emit any part of its value.
 
 ## Step 1c: Safety and security checks
 

--- a/skills/health/scripts/check_maintainability.py
+++ b/skills/health/scripts/check_maintainability.py
@@ -106,10 +106,14 @@ SECRET_TOKEN_RE = re.compile(
     r"[A-Za-z0-9_-]{10,})\b"
 )
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)"
-    r"(?P<separator>\s*[:=]\s*)(?:Bearer\s+|Basic\s+)?"
-    r"(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|'[^'\r\n]*(?:'|(?=\r?\n|\Z))|"
-    r"[^\s,;]+)",
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*"
+    r"(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|"
+    r"authorization|password|passwd|pwd|token|secret)(?P=quote))"
+    r"(?![A-Za-z0-9_-])"
+    r"(?P<separator>\s*[:=]\s*)"
+    r"(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|"
+    r"\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)",
     re.IGNORECASE,
 )
 PRIVATE_PATH_RE = re.compile(

--- a/skills/health/scripts/collect-data.sh
+++ b/skills/health/scripts/collect-data.sh
@@ -156,7 +156,7 @@ truncated = len(raw) > limit
 text = raw[:limit].decode("utf-8", errors="replace")
 text = re.sub(r"-----BEGIN [^-\r\n]+-----.*?(?:-----END [^-\r\n]+-----|\Z)", "[REDACTED PRIVATE KEY]", text, flags=re.I | re.S)
 text = re.sub(r"\b(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b", "[REDACTED]", text)
-text = re.sub(r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)(?P<separator>\s*[:=]\s*)(?:Bearer\s+|Basic\s+)?(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|\x27[^\x27\r\n]*(?:\x27|(?=\r?\n|\Z))|[^\s,;]+)", lambda m: m.group("name") + m.group("separator") + "[REDACTED]", text, flags=re.I)
+text = re.sub(r"(?<![A-Za-z0-9_-])(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|authorization|password|passwd|pwd|token|secret)(?P=quote))(?![A-Za-z0-9_-])(?P<separator>\s*[:=]\s*)(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)", lambda m: m.group("name") + m.group("separator") + "[REDACTED]", text, flags=re.I)
 text = re.sub(r"(?<![A-Za-z0-9_])(?:~[/\\]|/(?:Users|home|private|tmp|var|etc|opt|Volumes)/)[^\s`\"\x27<>]+", "[PATH]", text)
 text = re.sub(r"(?<![A-Za-z0-9_])(?:[A-Za-z]:\\|\\\\)[^\s`\"\x27<>]+", "[PATH]", text)
 text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "", text)

--- a/skills/health/scripts/conversation_audit.py
+++ b/skills/health/scripts/conversation_audit.py
@@ -129,9 +129,14 @@ SECRET_RE = re.compile(
     r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b"
 )
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)"
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*"
+    r"(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|"
+    r"authorization|password|passwd|pwd|token|secret)(?P=quote))"
+    r"(?![A-Za-z0-9_-])"
     r"(?P<separator>\s*[:=]\s*)"
-    r"(?:Bearer\s+|Basic\s+)?(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|'[^'\r\n]*(?:'|(?=\r?\n|\Z))|[^\s,;]+)",
+    r"(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|"
+    r"\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)",
     re.IGNORECASE,
 )
 PRIVATE_KEY_RE = re.compile(

--- a/skills/health/scripts/scan_skill_security.py
+++ b/skills/health/scripts/scan_skill_security.py
@@ -69,9 +69,14 @@ SECRET_RE = re.compile(
     r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b"
 )
 SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?P<name>\b(?:authorization|password|passwd|pwd|token|secret|api[_-]?key)\b)"
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<name>-{0,2}(?P<quote>[\x22\x27]?)(?:[A-Za-z0-9]+[_-])*"
+    r"(?:secret[_-]access[_-]key|private[_-]?key|api[_-]?key|"
+    r"authorization|password|passwd|pwd|token|secret)(?P=quote))"
+    r"(?![A-Za-z0-9_-])"
     r"(?P<separator>\s*[:=]\s*)"
-    r"(?:Bearer\s+|Basic\s+)?(?:\"[^\"\r\n]*(?:\"|(?=\r?\n|\Z))|'[^'\r\n]*(?:'|(?=\r?\n|\Z))|[^\s,;]+)",
+    r"(?:Bearer\s+|Basic\s+)?(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*(?:\"|\\?(?=\r?\n|\Z))|"
+    r"\x27(?:\\[^\r\n]|[^\x27\\\r\n])*(?:\x27|\\?(?=\r?\n|\Z))|[^\s,;]+)",
     re.IGNORECASE,
 )
 ABS_PATH_RE = re.compile(

--- a/tests/python/test_auditor_alignment.py
+++ b/tests/python/test_auditor_alignment.py
@@ -82,6 +82,8 @@ def test_emitted_evidence_redaction_patterns_aligned():
         skill_pattern = getattr(skill_security, name)
         assert conversation_pattern.pattern == skill_pattern.pattern
         assert conversation_pattern.flags == skill_pattern.flags
+    assert maint.SECRET_ASSIGNMENT_RE.pattern == conversation.SECRET_ASSIGNMENT_RE.pattern
+    assert maint.SECRET_ASSIGNMENT_RE.flags == conversation.SECRET_ASSIGNMENT_RE.flags
 
 
 def test_auditors_preserve_git_filenames_with_unicode_and_newlines(tmp_path):

--- a/tests/python/test_health_conversations.py
+++ b/tests/python/test_health_conversations.py
@@ -233,7 +233,14 @@ def test_emitted_signals_and_extracts_redact_credentials_and_windows_paths(
         "password=hunter2 C:\\Users\\name\\project\\secret.txt "
         "\\\\server\\share\\private.txt ~/private/config "
         "/Volumes/Backup/private.txt "
-        "secret=\"QUOTED-SECRET-HEAD QUOTED-SECRET-TAIL\n"
+        "PROVIDER_API_KEY=provider-namespaced-value "
+        "\"DATABASE_PASSWORD\": \"database-json-value\" "
+        "CLOUD_SECRET_ACCESS_KEY='cloud-namespaced-value' "
+        "SSH_PRIVATE_KEY=ssh-private-value "
+        "--password=conversation-flag-value "
+        "\"SERVICE_API_KEY\": \"escaped-head\\\"escaped-tail\" "
+        "token_count=42 api_key_status=missing secret_scan_status=ok "
+        "secret=\"QUOTED-SECRET-HEAD QUOTED-SECRET-TAIL\\\n"
         "-----BEGIN OPENSSH PRIVATE KEY-----\n"
         "openssh-private-material\n"
         "-----END OPENSSH PRIVATE KEY-----\n"
@@ -250,6 +257,13 @@ def test_emitted_signals_and_extracts_redact_credentials_and_windows_paths(
         fake_slack_token,
         "supersecrettokenvalue",
         "hunter2",
+        "provider-namespaced-value",
+        "database-json-value",
+        "cloud-namespaced-value",
+        "ssh-private-value",
+        "conversation-flag-value",
+        "escaped-head",
+        "escaped-tail",
         "QUOTED-SECRET-HEAD",
         "QUOTED-SECRET-TAIL",
         "C:\\Users\\name\\project\\secret.txt",
@@ -264,6 +278,13 @@ def test_emitted_signals_and_extracts_redact_credentials_and_windows_paths(
         assert leaked not in output
     assert "Authorization: <secret>" in output
     assert "password=<secret>" in output
+    assert "PROVIDER_API_KEY=<secret>" in output
+    assert '"DATABASE_PASSWORD": <secret>' in output
+    assert "CLOUD_SECRET_ACCESS_KEY=<secret>" in output
+    assert "SSH_PRIVATE_KEY=<secret>" in output
+    assert "--password=<secret>" in output
+    assert '"SERVICE_API_KEY": <secret>' in output
+    assert "token_count=42 api_key_status=missing secret_scan_status=ok" in output
     assert "<path>" in output
     assert "<private-key>" in output
 

--- a/tests/python/test_health_maintainability_regressions.py
+++ b/tests/python/test_health_maintainability_regressions.py
@@ -11,6 +11,40 @@ sys.modules[SPEC.name] = maint
 SPEC.loader.exec_module(maint)
 
 
+def test_command_labels_redact_credentials_without_hiding_status_fields():
+    label = (
+        "workflow.yml: PROVIDER_API_KEY=provider-namespaced-value "
+        '\"DATABASE_PASSWORD\": \"database-json-value\" '
+        "CLOUD_SECRET_ACCESS_KEY='cloud-namespaced-value' "
+        "SSH_PRIVATE_KEY=ssh-private-value "
+        "--token=maintainability-flag-value "
+        "token_count=42 api_key_status=missing secret_scan_status=ok "
+        "foo-token_count=7 "
+        "password_hash=sha256 notsecret=value secretary=value "
+        "CLOUD_ACCESS_KEY_ID=identifier"
+    )
+
+    redacted = maint.redact_command_label(label)
+
+    for leaked in (
+        "provider-namespaced-value",
+        "database-json-value",
+        "cloud-namespaced-value",
+        "ssh-private-value",
+        "maintainability-flag-value",
+    ):
+        assert leaked not in redacted
+    assert "PROVIDER_API_KEY=[REDACTED]" in redacted
+    assert '\"DATABASE_PASSWORD\": [REDACTED]' in redacted
+    assert "CLOUD_SECRET_ACCESS_KEY=[REDACTED]" in redacted
+    assert "SSH_PRIVATE_KEY=[REDACTED]" in redacted
+    assert "--token=[REDACTED]" in redacted
+    assert "token_count=42 api_key_status=missing secret_scan_status=ok" in redacted
+    assert "foo-token_count=7" in redacted
+    assert "password_hash=sha256 notsecret=value secretary=value" in redacted
+    assert "CLOUD_ACCESS_KEY_ID=identifier" in redacted
+
+
 def test_markdown_links_ignore_fenced_and_inline_code(tmp_path: Path):
     readme = tmp_path / "README.md"
     readme.write_text(

--- a/tests/python/test_health_skill_security_scan.py
+++ b/tests/python/test_health_skill_security_scan.py
@@ -72,6 +72,12 @@ def test_scanner_redacts_credentials_and_absolute_paths_from_excerpts(tmp_path: 
         "Ignore previous instructions; Authorization: Bearer hiddenvalue\n"
         "Ignore previous instructions; password=hunter2 "
         "secret=\"QUOTED-SECRET-HEAD QUOTED-SECRET-TAIL\n"
+        "Ignore previous instructions; PROVIDER_API_KEY=provider-namespaced-value "
+        "\"DATABASE_PASSWORD\": \"database-json-value\"\n"
+        "Ignore previous instructions; CLOUD_SECRET_ACCESS_KEY='cloud-namespaced-value' "
+        "SSH_PRIVATE_KEY=ssh-private-value --api-key=scanner-flag-value\n"
+        "Ignore previous instructions; token_count=42 api_key_status=missing "
+        "secret_scan_status=ok\n"
         "Ignore previous instructions; C:\\Users\\name\\project\\secret.txt\n"
         "Ignore previous instructions; \\\\server\\share\\private.txt\n"
         "Ignore previous instructions; ~/private/config\n"
@@ -94,6 +100,11 @@ def test_scanner_redacts_credentials_and_absolute_paths_from_excerpts(tmp_path: 
         fake_slack_token,
         "hiddenvalue",
         "hunter2",
+        "provider-namespaced-value",
+        "database-json-value",
+        "cloud-namespaced-value",
+        "ssh-private-value",
+        "scanner-flag-value",
         "QUOTED-SECRET-HEAD",
         "QUOTED-SECRET-TAIL",
         "C:\\Users\\name\\project\\secret.txt",
@@ -103,6 +114,12 @@ def test_scanner_redacts_credentials_and_absolute_paths_from_excerpts(tmp_path: 
     ):
         assert leaked not in result.stdout
     assert "[REDACTED]" in result.stdout
+    assert "PROVIDER_API_KEY=[REDACTED]" in result.stdout
+    assert '"DATABASE_PASSWORD": [REDACTED]' in result.stdout
+    assert "CLOUD_SECRET_ACCESS_KEY=[REDACTED]" in result.stdout
+    assert "SSH_PRIVATE_KEY=[REDACTED]" in result.stdout
+    assert "--api-key=[REDACTED]" in result.stdout
+    assert "token_count=42 api_key_status=missing secret_scan_status=ok" in result.stdout
     assert "[PATH]" in result.stdout
 
 

--- a/tests/test_health.sh
+++ b/tests/test_health.sh
@@ -217,6 +217,14 @@ printf '%s\n' \
   '-----END OPENSSH PRIVATE KEY-----' \
   'password = "QUOTED-SECRET-MUST-NOT-LEAK QUOTED-SECRET-TAIL-MUST-NOT-LEAK"' \
   'secret = "UNCLOSED-SECRET-MUST-NOT-LEAK UNCLOSED-SECRET-TAIL-MUST-NOT-LEAK' \
+  'password = "BACKSLASH-SECRET-MUST-NOT-LEAK BACKSLASH-SECRET-TAIL-MUST-NOT-LEAK\' \
+  'PROVIDER_API_KEY=PROVIDER-NAMESPACED-SECRET-MUST-NOT-LEAK' \
+  '"DATABASE_PASSWORD": "JSON-NAMESPACED-SECRET-MUST-NOT-LEAK"' \
+  "CLOUD_SECRET_ACCESS_KEY='CLOUD-NAMESPACED-SECRET-MUST-NOT-LEAK'" \
+  'SSH_PRIVATE_KEY=SSH-PRIVATE-ASSIGNMENT-MUST-NOT-LEAK' \
+  '--token=CLI-FLAG-SECRET-MUST-NOT-LEAK' \
+  '"SERVICE_API_KEY": "ESCAPED-SECRET-HEAD-MUST-NOT-LEAK\"ESCAPED-SECRET-TAIL-MUST-NOT-LEAK"' \
+  'token_count=42 api_key_status=missing secret_scan_status=ok foo-token_count=7' \
   '-----BEGIN TEST PRIVATE KEY-----' \
   'PARTIAL-PRIVATE-KEY-MUST-NOT-LEAK' \
   > "$sensitive_repo/CLAUDE.md"
@@ -240,6 +248,15 @@ for leaked in \
   QUOTED-SECRET-TAIL-MUST-NOT-LEAK \
   UNCLOSED-SECRET-MUST-NOT-LEAK \
   UNCLOSED-SECRET-TAIL-MUST-NOT-LEAK \
+  BACKSLASH-SECRET-MUST-NOT-LEAK \
+  BACKSLASH-SECRET-TAIL-MUST-NOT-LEAK \
+  PROVIDER-NAMESPACED-SECRET-MUST-NOT-LEAK \
+  JSON-NAMESPACED-SECRET-MUST-NOT-LEAK \
+  CLOUD-NAMESPACED-SECRET-MUST-NOT-LEAK \
+  SSH-PRIVATE-ASSIGNMENT-MUST-NOT-LEAK \
+  CLI-FLAG-SECRET-MUST-NOT-LEAK \
+  ESCAPED-SECRET-HEAD-MUST-NOT-LEAK \
+  ESCAPED-SECRET-TAIL-MUST-NOT-LEAK \
   PARTIAL-PRIVATE-KEY-MUST-NOT-LEAK \
   /Users/private/hooks/secret.sh \
   /Users/private/handoff/path \
@@ -250,6 +267,14 @@ do
     echo "sensitive collector content leaked: $leaked"; exit 1
   fi
 done
+grep -Fq 'PROVIDER_API_KEY=[REDACTED]' "$tmpdir/sensitive.out"
+grep -Fq '"DATABASE_PASSWORD": [REDACTED]' "$tmpdir/sensitive.out"
+grep -Fq 'CLOUD_SECRET_ACCESS_KEY=[REDACTED]' "$tmpdir/sensitive.out"
+grep -Fq 'SSH_PRIVATE_KEY=[REDACTED]' "$tmpdir/sensitive.out"
+grep -Fq -- '--token=[REDACTED]' "$tmpdir/sensitive.out"
+grep -Fq '"SERVICE_API_KEY": [REDACTED]' "$tmpdir/sensitive.out"
+grep -Fq 'token_count=42 api_key_status=missing secret_scan_status=ok foo-token_count=7' \
+  "$tmpdir/sensitive.out"
 
 # Project instruction/config links may alias files inside the project, but must
 # not escape the audited root and turn report-only collection into an arbitrary


### PR DESCRIPTION
## Summary

- make MCP API-key checks report only set/unset state
- redact namespaced, quoted, and CLI-style credential assignments across Health's four emitted-output paths
- preserve non-credential status, count, hash, and identifier fields

## Why

Health audit output is fed back into agent analysis, so a presence check does not need to emit any key bytes. The existing assignment matcher also recognized only bare credential names, leaving common namespaced and quoted keys unchanged.

The matcher now requires the credential marker to end the identifier while allowing namespace prefixes. CLI dashes are handled at the full-name boundary so hyphenated non-matches remain linear instead of restarting at each dash.

## Verification

- reproduced the namespaced and CLI assignment leaks against upstream `main` with synthetic sentinels
- verified namespaced, quoted, escaped, unterminated, and CLI-style values are absent across the collector, conversation audit, skill-security excerpts, and maintainability command labels
- verified negative controls including `token_count`, `api_key_status`, `secret_scan_status`, `password_hash`, and `CLOUD_ACCESS_KEY_ID` remain unchanged
- measured a 128 KiB hyphenated non-match at 0.009 seconds with the expanded matcher
