### PR TITLE
feat: check - question the approach before listing patches

### DIFF
--- a/plugins/waza/skills/check/SKILL.md
+++ b/plugins/waza/skills/check/SKILL.md
@@ -137,6 +137,12 @@ Drift signals (examples, not exhaustive -- any one is enough to label drift):
 - A new abstraction or helper was introduced that is not required by the goal
 - A maintainability, review, or cleanup change quietly adds user-visible UI, default config, workflow permissions, or release behavior
 
+## Question the Approach, Not Just the Diff
+
+Scope drift checks the diff against the stated goal; this checks the goal against the approach. Skip when the user declares the route settled or the repo's design docs record the decision -- do not re-litigate deliberate trade-offs.
+
+When findings cluster on one root cause -- the same bug class patched repeatedly, permission or state problems that follow from the architecture itself, a simple problem made complex -- stop listing patches and state the route verdict first: keep / adjust / replace / insufficient information. Compare a real alternative only when it eliminates the problem class at an acceptable migration cost; never manufacture one to fill the report. No patch list before the verdict.
+
 ## Pattern-Fix Completeness
 
 When the diff fixes one instance of a class-of-bug (a missing validation, a wrong selector, an off-by-one, a missing lock), the same shape often lives elsewhere. Extract the pattern signature, `grep -rn` it across the repo (exclude generated dirs), and confirm sibling instances were also handled. List any unswept sibling: flag it as a hard stop when it carries the same risk, advisory when lower-risk. For a deeper sweep playbook, see hunt's Scope Blast Mode.

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -137,6 +137,12 @@ Drift signals (examples, not exhaustive -- any one is enough to label drift):
 - A new abstraction or helper was introduced that is not required by the goal
 - A maintainability, review, or cleanup change quietly adds user-visible UI, default config, workflow permissions, or release behavior
 
+## Question the Approach, Not Just the Diff
+
+Scope drift checks the diff against the stated goal; this checks the goal against the approach. Skip when the user declares the route settled or the repo's design docs record the decision -- do not re-litigate deliberate trade-offs.
+
+When findings cluster on one root cause -- the same bug class patched repeatedly, permission or state problems that follow from the architecture itself, a simple problem made complex -- stop listing patches and state the route verdict first: keep / adjust / replace / insufficient information. Compare a real alternative only when it eliminates the problem class at an acceptable migration cost; never manufacture one to fill the report. No patch list before the verdict.
+
 ## Pattern-Fix Completeness
 
 When the diff fixes one instance of a class-of-bug (a missing validation, a wrong selector, an off-by-one, a missing lock), the same shape often lives elsewhere. Extract the pattern signature, `grep -rn` it across the repo (exclude generated dirs), and confirm sibling instances were also handled. List any unswept sibling: flag it as a hard stop when it carries the same risk, advisory when lower-risk. For a deeper sweep playbook, see hunt's Scope Blast Mode.


### PR DESCRIPTION
## What

Adds one section to `skills/check/SKILL.md`: **Question the Approach, Not Just the Diff**, between "Did We Build What Was Asked?" and "Pattern-Fix Completeness". Pure insertion, no existing text changed. Mirror regenerated with `make regenerate`; `WAZA_SMOKE_OFFLINE=1 make test` passes.

## Why

`check` verifies the diff against the stated goal (scope drift), but nothing verifies the goal against the approach. When the approach itself is wrong, review output degrades observably: findings keep landing inside the approach's frame, and each re-review round surfaces "new" symptoms of the same root cause instead of eliminating it. The escalation signal — findings clustering on one root cause — only exists at review time, so it can't live in `/think` (which runs before anything exists to review) or in scope drift (which assumes the goal is right and only checks the diff against it).

## Behavior

- Triggered, not per-run: skipped with one line when the user declares the route settled or design docs record the decision. Zero cost for deliberate trade-offs.
- On trigger: the route verdict (keep / adjust / replace / insufficient information) comes before any patch list.
- Bars manufacturing alternatives to fill the report — a sound approach gets kept, with reasons.

Happy to move this into `references/review-patterns.md` as a triggered pattern with a one-line pointer here instead, if you'd rather keep the entrypoint shorter.
